### PR TITLE
Remove Pathname dependency. Update browsers.yml.

### DIFF
--- a/lib/device_detector/parser.rb
+++ b/lib/device_detector/parser.rb
@@ -1,7 +1,7 @@
 class DeviceDetector
   class Parser < Struct.new(:user_agent)
 
-    ROOT = Pathname.new(File.expand_path('../../..', __FILE__))
+    ROOT = File.expand_path('../../..', __FILE__)
 
     def name
       regex_meta['name']

--- a/regexes/browsers.yml
+++ b/regexes/browsers.yml
@@ -5,6 +5,14 @@
 # @license http://www.gnu.org/licenses/lgpl.html LGPL v3 or later
 ###############
 
+#newer versions of IE
+- regex: 'Edge[ /](\d+[\.\d]+)'
+  name: 'Internet Explorer'
+  version: '$1'
+  engine:
+    default: 'Edge'
+
+
 #SailfishBrowser
 - regex: 'SailfishBrowser(?:/(\d+[\.\d]+))?'
   name: 'Sailfish Browser'
@@ -627,6 +635,11 @@
   engine:
     default: 'Blink'
 
+# MIUI Browser
+- regex: 'MIUIBrowser(?:/(\d+[\.\d]+))?'
+  name: 'MIUI Browser'
+  version: '$1'
+
 #Nokia Browser
 - regex: '(?:NokiaBrowser|BrowserNG)(?:/(\d+[\.\d]+))?'
   name: 'Nokia Browser'
@@ -739,4 +752,3 @@
   version: '$1'
   engine:
     default: 'WebKit'
-


### PR DESCRIPTION
1) Previously trying to load the library would throw:
`lib/device_detector/parser.rb:4:in '<class:Parser>': uninitialized constant DeviceDetector::Parser::Pathname (NameError)`

Adding a `require 'pathname'` at the top of `parser.rb` will resolve this issue--but why require a library we don't actually need? So I removed the Pathname dependency and references the path explicitly.

2) The detection file for `browsers.yml` was out of date, so I pulled in the latest one from https://github.com/piwik/device-detector. However, even that one was not good enough to detect the browser version number for all Safari devices, so I updated it with some custom detection Regex. Now it will work for User Agents like this:
```ruby
ua = "Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12B466 WindVane tae_sdk_ios_1.3.0 Weibo (iPhone5,2__weibo__5.1.0__iphone__os8.1.3)"
device = DeviceDetector.new ua
device.full_version
#=> "600.1.4"
```
Previous versions of `browser.yml` would just return an empty string for the above UA.