### PR TITLE
Preliminary implementation of digesting mobile device regexes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,17 @@ Or install it yourself as:
 user_agent = 'foo'
 client = DeviceDetector.new(user_agent)
 
-client.name # => Chrome
+client.name # => 'Chrome'
 client.full_version # => '30.0.1599.69'
 client.known? # => true, will return false if user_agent is unknown
 
-client.os_name # => Mac
+client.os_name # => 'Mac'
 client.os_full_version # => '10_8_5'
+
+# For many devices, you can also query the device name (usually the model name)
+# Look into regexes/devices/mobiles.yml to see what devices can be detected
+client.device_name # => 'iPhone 5'
+client.device_type # => 'smartphone'
 ```
 
 `DeviceDetector` will return `nil` on all attributes, if the `user_agent` is unknown.
@@ -54,7 +59,6 @@ client.os_full_version # => '10_8_5'
 You can tune the amount of keys that will get saved in the cache:
 
 ```ruby
-
 # You have to call this code **before** you initialize the Detector
 DeviceDetector.configure do |config|
   config.max_cache_keys = 20_000 # if you have enough RAM, proceed with care

--- a/lib/device_detector.rb
+++ b/lib/device_detector.rb
@@ -5,6 +5,7 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'device_detector/version'
 require 'device_detector/version_extractor'
+require 'device_detector/model_extractor'
 require 'device_detector/memory_cache'
 require 'device_detector/parser'
 require 'device_detector/bot'

--- a/lib/device_detector.rb
+++ b/lib/device_detector.rb
@@ -4,6 +4,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'device_detector/version'
+require 'device_detector/metadata_extractor'
 require 'device_detector/version_extractor'
 require 'device_detector/model_extractor'
 require 'device_detector/memory_cache'
@@ -42,7 +43,7 @@ class DeviceDetector
   end
 
   def device_type
-    device.device_type
+    device.type
   end
 
   def known?

--- a/lib/device_detector.rb
+++ b/lib/device_detector.rb
@@ -9,6 +9,7 @@ require 'device_detector/memory_cache'
 require 'device_detector/parser'
 require 'device_detector/bot'
 require 'device_detector/client'
+require 'device_detector/device'
 require 'device_detector/os'
 
 class DeviceDetector
@@ -33,6 +34,14 @@ class DeviceDetector
 
   def os_full_version
     os.full_version
+  end
+
+  def device_name
+    device.name
+  end
+
+  def device_type
+    device.device_type
   end
 
   def known?
@@ -82,6 +91,10 @@ class DeviceDetector
 
   def client
     @client ||= Client.new(user_agent)
+  end
+
+  def device
+    @device ||= Device.new(user_agent)
   end
 
   def os

--- a/lib/device_detector/device.rb
+++ b/lib/device_detector/device.rb
@@ -6,7 +6,7 @@ class DeviceDetector
     end
 
     def name
-      regex_meta['model']
+      ModelExtractor.new(user_agent, regex_meta).call
     end
 
     def device_type

--- a/lib/device_detector/device.rb
+++ b/lib/device_detector/device.rb
@@ -1,0 +1,54 @@
+class DeviceDetector
+  class Device < Parser
+
+    def known?
+      regex_meta.any?
+    end
+
+    def name
+      regex_meta['model']
+    end
+
+    def device_type
+      regex_meta['device']
+    end
+
+    private
+
+    def filenames
+      [
+        'devices/mobiles.yml'
+      ]
+    end
+
+    # Overwrite the default parser handling logic
+    def self.regexes_for(filepaths)
+      @regexes ||=
+        begin
+          regexes = YAML.load(filepaths.map { |filepath| File.read(filepath) }.join)
+
+          recursive_regex_parser(regexes)
+        end
+    end
+
+    def self.recursive_regex_parser(nested_regex)
+      nested_regex.map { |base, nest|
+
+        if !nest.nil? && nest.include?('models')
+          recursive_regex_parser nest['models']
+        else
+          case base.class.to_s
+            when 'Hash'
+              base['regex'] = Regexp.new base['regex']
+              base
+            else
+              nest['regex'] = Regexp.new nest['regex']
+              nest
+          end
+        end
+
+      }.flatten
+    end
+
+  end
+end

--- a/lib/device_detector/metadata_extractor.rb
+++ b/lib/device_detector/metadata_extractor.rb
@@ -2,22 +2,23 @@ class DeviceDetector
   class MetadataExtractor < Struct.new(:user_agent, :regex_meta)
 
     def call
-      regex_meta.any? ? extract_version : nil
+      regex_meta.any? ? extract_metadata : nil
     end
 
     private
 
     def metadata_string
-      fail "#{self.name} (a child of MetadataExtractor) must implement the '#{__method__}' method."
+      message = "#{self.name} (a child of MetadataExtractor) must implement the '#{__method__}' method."
+      fail NotImplementedError, message
     end
 
-    def extract_version
+    def extract_metadata
       user_agent.match(regex) do |match_data|
-        replace_version_string_with(match_data)
+        replace_metadata_string_with(match_data)
       end
     end
 
-    def replace_version_string_with(match_data)
+    def replace_metadata_string_with(match_data)
       string = metadata_string
 
       1.upto(9) do |index|

--- a/lib/device_detector/metadata_extractor.rb
+++ b/lib/device_detector/metadata_extractor.rb
@@ -1,0 +1,37 @@
+class DeviceDetector
+  class MetadataExtractor < Struct.new(:user_agent, :regex_meta)
+
+    def call
+      regex_meta.any? ? extract_version : nil
+    end
+
+    private
+
+    def metadata_string
+      fail "#{self.name} (a child of MetadataExtractor) must implement the '#{__method__}' method."
+    end
+
+    def extract_version
+      user_agent.match(regex) do |match_data|
+        replace_version_string_with(match_data)
+      end
+    end
+
+    def replace_version_string_with(match_data)
+      string = metadata_string
+
+      1.upto(9) do |index|
+        matched_data = String(match_data[index])
+        string = string.gsub(/\$#{index}/, matched_data)
+      end
+
+      string.strip
+    end
+
+    def regex
+      Regexp.new(regex_meta['regex'])
+    end
+
+  end
+end
+

--- a/lib/device_detector/model_extractor.rb
+++ b/lib/device_detector/model_extractor.rb
@@ -4,7 +4,7 @@ class DeviceDetector
     private
 
     def metadata_string
-      regex_meta['model']
+      String(regex_meta['model'])
     end
 
   end

--- a/lib/device_detector/model_extractor.rb
+++ b/lib/device_detector/model_extractor.rb
@@ -3,7 +3,7 @@ class DeviceDetector
 
     private
 
-    def version_string
+    def metadata_string
       regex_meta['model']
     end
 

--- a/lib/device_detector/model_extractor.rb
+++ b/lib/device_detector/model_extractor.rb
@@ -1,0 +1,11 @@
+class DeviceDetector
+  class ModelExtractor < VersionExtractor
+
+    private
+
+    def version_string
+      regex_meta['model']
+    end
+
+  end
+end

--- a/lib/device_detector/model_extractor.rb
+++ b/lib/device_detector/model_extractor.rb
@@ -1,5 +1,5 @@
 class DeviceDetector
-  class ModelExtractor < VersionExtractor
+  class ModelExtractor < MetadataExtractor
 
     private
 

--- a/lib/device_detector/parser.rb
+++ b/lib/device_detector/parser.rb
@@ -1,7 +1,7 @@
 class DeviceDetector
   class Parser < Struct.new(:user_agent)
 
-    ROOT = Pathname.new(File.expand_path('../../..', __FILE__))
+    ROOT = File.expand_path('../../..', __FILE__)
 
     def name
       regex_meta['name']

--- a/lib/device_detector/parser.rb
+++ b/lib/device_detector/parser.rb
@@ -43,12 +43,17 @@ class DeviceDetector
     def self.regexes_for(filepaths)
       @regexes ||=
         begin
-          regexes = YAML.load(filepaths.map { |filepath| File.read(filepath) }.join)
-          regexes.map do |meta|
-            meta['regex'] = Regexp.new(meta['regex'])
-            meta
-          end
+          raw_files = filepaths.map { |filepath| File.read(filepath) }.join
+          regexes = YAML.load(raw_files)
+          parse_regexes(regexes)
         end
+    end
+
+    def self.parse_regexes(regexes)
+      regexes.map do |meta|
+        meta['regex'] = Regexp.new(meta['regex'])
+        meta
+      end
     end
 
   end

--- a/lib/device_detector/version_extractor.rb
+++ b/lib/device_detector/version_extractor.rb
@@ -18,7 +18,7 @@ class DeviceDetector
     end
 
     def replace_version_string_with(match_data)
-      string = version_string
+      string = version_string.to_s
 
       1.upto(9) do |index|
         if match_data[index]

--- a/lib/device_detector/version_extractor.rb
+++ b/lib/device_detector/version_extractor.rb
@@ -21,10 +21,14 @@ class DeviceDetector
       string = version_string
 
       1.upto(9) do |index|
-        string = string.gsub(/\$#{index}/, match_data[index]) if match_data[index]
+        if match_data[index]
+          string = string.gsub(/\$#{index}/, match_data[index])
+        else
+          string = string.gsub(/\$#{index}/, '')
+        end
       end
 
-      string
+      string.strip
     end
 
     def regex

--- a/lib/device_detector/version_extractor.rb
+++ b/lib/device_detector/version_extractor.rb
@@ -1,38 +1,10 @@
 class DeviceDetector
-  class VersionExtractor < Struct.new(:user_agent, :regex_meta)
-
-    def call
-      regex_meta.any? ? extract_version : nil
-    end
+  class VersionExtractor < MetadataExtractor
 
     private
 
-    def version_string
-      regex_meta['version']
-    end
-
-    def extract_version
-      user_agent.match(regex) do |match_data|
-        replace_version_string_with(match_data)
-      end
-    end
-
-    def replace_version_string_with(match_data)
-      string = version_string.to_s
-
-      1.upto(9) do |index|
-        if match_data[index]
-          string = string.gsub(/\$#{index}/, match_data[index])
-        else
-          string = string.gsub(/\$#{index}/, '')
-        end
-      end
-
-      string.strip
-    end
-
-    def regex
-      Regexp.new(regex_meta['regex'])
+    def metadata_string
+      String(regex_meta['version'])
     end
 
   end

--- a/regexes/browsers.yml
+++ b/regexes/browsers.yml
@@ -5,6 +5,14 @@
 # @license http://www.gnu.org/licenses/lgpl.html LGPL v3 or later
 ###############
 
+#newer versions of IE
+- regex: 'Edge[ /](\d+[\.\d]+)'
+  name: 'Internet Explorer'
+  version: '$1'
+  engine:
+    default: 'Edge'
+
+
 #SailfishBrowser
 - regex: 'SailfishBrowser(?:/(\d+[\.\d]+))?'
   name: 'Sailfish Browser'
@@ -627,6 +635,11 @@
   engine:
     default: 'Blink'
 
+# MIUI Browser
+- regex: 'MIUIBrowser(?:/(\d+[\.\d]+))?'
+  name: 'MIUI Browser'
+  version: '$1'
+
 #Nokia Browser
 - regex: '(?:NokiaBrowser|BrowserNG)(?:/(\d+[\.\d]+))?'
   name: 'Nokia Browser'
@@ -739,4 +752,3 @@
   version: '$1'
   engine:
     default: 'WebKit'
-

--- a/regexes/devices/mobiles.yml
+++ b/regexes/devices/mobiles.yml
@@ -224,10 +224,10 @@ Apple:
       model: 'iPhone 5'
       device: 'smartphone'
     - regex: '(?:Apple-)?iPhone5[C,][34]'
-      model: 'iPhone 5c'
+      model: 'iPhone 5C'
       device: 'smartphone'
     - regex: '(?:Apple-)?iPhone6[C,][12]'
-      model: 'iPhone 5s'
+      model: 'iPhone 5S'
       device: 'smartphone'
     - regex: '(?:Apple-)?iPhone7[C,]1'
       model: 'iPhone 6 Plus'
@@ -331,7 +331,7 @@ Acer:
 
 # Airness
 Airness:
-  regex: 'AIRNESS-([a-z0-9]+)'
+  regex: 'AIRNESS-([\w0-9]+)'
   device: 'feature phone'
   model: '$1'
 

--- a/regexes/devices/mobiles.yml
+++ b/regexes/devices/mobiles.yml
@@ -1,0 +1,2412 @@
+###############
+# Device Detector - The Universal Device Detection library for parsing User Agents
+#
+# @link http://piwik.org
+# @license http://www.gnu.org/licenses/lgpl.html LGPL v3 or later
+###############
+
+'Tunisie Telecom':
+  regex: 'StarTrail TT Build'
+  device: 'smartphone'
+  model: 'StarTrail'
+
+# SFR
+SFR:
+  regex: 'StarShine|StarTrail|STARADDICT|StarText|StarNaute|StarXtrem|StarTab'
+  device: 'smartphone'
+  models:
+    - regex: 'StarXtrem Build'
+      model: 'StarXtrem' # ZTE
+    - regex: 'StarTrail Build'
+      model: 'StarTrail' # ZTE
+    - regex: 'StarTrail II Build'
+      model: 'StarTrail 2' # Huawei Ascend Y200
+    - regex: 'StarTrail III Build'
+      model: 'StarTrail 3' # ZTE
+    - regex: 'StarTrail ?4 Build'
+      model: 'StarTrail 4' # ZTE Blade Q
+    - regex: 'StarShine Build'
+      model: 'StarShine' # Huawei U8180
+    - regex: 'StarShine II Build'
+      model: 'StarShine 2' # ZTE
+    - regex: 'STARADDICT Build'
+      model: 'Staraddict' # ZTE
+    - regex: 'STARADDICT II Build'
+      model: 'Staraddict 2' # Alcatel One Touch 995
+    - regex: 'STARADDICT II Plus Build'
+      model: 'Staraddict 2 Plus' # ZTE Grand X
+    - regex: 'STARADDICT III Build'
+      model: 'Staraddict 3' # Coolpad 8861U
+    - regex: 'StarText Build'
+      model: 'StarText' # ZTE
+    - regex: 'StarText II Build'
+      model: 'StarText 2' # ZTE
+    - regex: 'StarNaute Build'
+      model: 'StarNaute' # ZTE Amigo
+    - regex: 'StarNaute II Build'
+      model: 'StarNaute 2' # ZTE
+    - regex: 'StarTab'
+      model: 'StarTab'
+      device: 'tablet'
+
+    - regex: '((?:StarShine|StarTrail|STARADDICT|StarText|StarNaute|StarXtrem)[^;/]*) Build'
+      model: '$1'
+
+# HTC
+HTC:
+  regex: 'HTC|Sprint (?:APA|ATP)|ADR(?!910L)[a-z0-9]+|NexusHD2|Amaze[ _]4G Build|(Desire|Sensation|Evo ?3D)[ _]?([^;/]+) Build|(Amaze[ _]4G|One ?[XELSV\+]+) Build|SPV E6[05]0'
+  device: 'smartphone'
+  models:
+    # explicit smartphone models
+    - regex: 'ADR6300'
+      model: 'Droid Incredible'
+    - regex: 'ADR6400L'
+      model: 'ThunderBolt'
+    - regex: 'ADR6410LRA'
+      model: 'Droid Incredible 3'
+    - regex: 'SPV E600'
+      model: 'Excalibur'
+    - regex: 'SPV E650'
+      model: 'Vox'
+
+    - regex: 'NexusHD2' # custom rom for hd2
+      model: 'HD2'
+    - regex: 'HTC[ _-]((?:Flyer|P715a).*) Build'
+      device: 'tablet'
+      model: '$1'
+    - regex: 'HTC[ _]([^/;]+) [0-9]+(?:\.[0-9]+)+ Build'
+      model: '$1'
+    - regex: 'HTC[ _]([^/;]+) Build'
+      model: '$1'
+    - regex: 'HTC[ _]([a-z0-9]+[ _-]?(?:[a-z0-9_+\-])*)'
+      model: '$1'
+    - regex: 'USCCHTC(\d+)'
+      model: '$1'
+    - regex: 'Sprint (ATP.*) Build'
+      device: 'tablet'
+      model: '$1 (Sprint)'
+    - regex: 'Sprint (APA.*) Build'
+      model: '$1 (Sprint)'
+    - regex: 'HTC(?:[\-/ ])?([a-z0-9\-_]+)'
+      model: '$1'
+    - regex: 'HTC;(?: )?([a-z0-9 ]+)'
+      model: '$1'
+    - regex: '(Desire|Sensation|Evo ?3D)[ _]?([^;/]+) Build'
+      model: '$1 $2'
+    - regex: '(Amaze[ _]4G|One ?[XELSV\+]*) Build'
+      model: '$1'
+    - regex: '(ADR.+) Build'
+      model: '$1'
+    - regex: '(ADR[a-z0-9]+)'
+      model: '$1'
+
+# NOKIA
+Nokia:
+  regex: 'Nokia|Lumia|Maemo RX|portalmmm/2\.0 N7|portalmmm/2\.0 NK|nok[0-9]+|Symbian.*\s([a-z0-9]+)$'
+  device: 'smartphone'
+  models:
+    - regex: 'Nokia(N[0-9]+)'
+      model: '$1'
+    - regex: 'Nokia-([a-z0-9]+)'
+      model: 'N$1'
+    - regex: 'NOKIA; ([a-z0-9\- ]+)'
+      model: '$1'
+    - regex: 'NOKIA[ _]?([a-z0-9\-]+)'
+      model: '$1'
+    - regex: 'NOKIA/([a-z0-9 ]+)'
+      model: '$1'
+    - regex: '(Lumia [a-z0-9\-]+)'
+      model: '$1'
+    - regex: 'Maemo RX-51 ([a-z0-9]+)'
+      model: '$1'
+    - regex: 'Maemo RX-34'
+      model: 'N800'
+    - regex: 'NokiaInternal|Nokia-WAP-Toolkit|Nokia-MIT-Browser|Nokia Mobile|Nokia Browser|Nokia/Series'
+      model: ''
+    - regex: 'portalmmm/2\.0 (N7[37]|NK[a-z0-9]+)'
+      model: '$1'
+    - regex: 'nok([0-9]+)'
+      model: '$1'
+    - regex: 'Symbian.*\s([a-z0-9]+)$'
+      device: 'feature phone'
+      model: '$1'
+
+# CnM
+CnM:
+  regex: 'CnM'
+  device: 'tablet'
+  models:
+    - regex: 'CnM[ \-](?:Touchpad|TP)[ \-]([0-9\.]+)'
+      model: 'Touchpad $1'
+
+# RIM/BlackBerry
+RIM:
+  regex: 'BB10;|BlackBerry|rim[0-9]+|PlayBook'
+  device: 'smartphone'
+  models:
+    - regex: 'BB10; ([a-z0-9\- ]+)\)'
+      model: 'BlackBerry $1'
+    - regex: 'PlayBook.+RIM Tablet OS'
+      model: 'BlackBerry Playbook'
+      device: 'tablet'
+    - regex: 'BlackBerry(?: )?([a-z0-9]+)'
+      model: 'BlackBerry $1'
+    - regex: 'rim([0-9]+)'
+      model: 'BlackBerry $1'
+    - regex: 'BlackBerry'
+      model: 'BlackBerry'
+
+# PALM
+Palm:
+  regex: '(?:Pre|Pixi)/(\d+)\.(\d+)|Palm|Treo|Xiino'
+  device: 'smartphone'
+  models:
+    - regex: '((?:Pre|Pixi))/(\d+\.\d+)'
+      model: '$1 $2'
+    - regex: 'Palm(?:[ -])?((?!OS|Source)[a-z0-9]+)'
+      model: '$1'
+    - regex: 'Treo([a-z0-9]+)'
+      model: 'Treo $1'
+    - regex: 'Tungsten'
+      model: 'Tungsten'
+    - regex: 'Xiino' # Browser for Palm OS only
+      model: ''
+
+# HP
+HP:
+  regex: 'TouchPad/\d+\.\d+|hp-tablet|HP ?iPAQ|webOS.*P160U|HP Slate|HP [78]'
+  device: 'smartphone'
+  models:
+    - regex: 'HP ([78][^/;]*) Build'
+      model: 'Slate $1'
+      device: 'tablet'
+    - regex: 'HP Slate ?(.+) Build'
+      model: 'Slate $1'
+      device: 'tablet'
+    - regex: 'HP Slate ?([0-9]+)'
+      model: 'Slate $1'
+      device: 'tablet'
+    - regex: 'TouchPad/(\d+\.\d+)|hp-tablet'
+      model: 'TouchPad'
+      device: 'tablet'
+    - regex: 'HP(?: )?iPAQ(?: )?([a-z0-9]+)'
+      model: 'iPAQ $1'
+    - regex: 'webOS.*(P160U)'
+      model: 'Veer'
+
+# TiPhone
+TiPhone:
+  regex: 'TiPhone ?([a-z0-9]+)'
+  device: 'smartphone'
+  model: '$1'
+
+# Apple
+Apple:
+  regex: 'AppleTV|(?:Apple-)?(?:iPad|iPhone)'
+  models:
+    # specific smartphone devices
+    - regex: '(?:Apple-)?iPhone1[C,]1'
+      model: 'iPhone'
+      device: 'smartphone'
+    - regex: '(?:Apple-)?iPhone1[C,]2'
+      model: 'iPhone 3G'
+      device: 'smartphone'
+    - regex: '(?:Apple-)?iPhone2[C,]1'
+      model: 'iPhone 3GS'
+      device: 'smartphone'
+    - regex: '(?:Apple-)?iPhone3[C,][123]'
+      model: 'iPhone 4'
+      device: 'smartphone'
+    - regex: '(?:Apple-)?iPhone4[C,]1'
+      model: 'iPhone 4S'
+      device: 'smartphone'
+    - regex: '(?:Apple-)?iPhone5[C,][12]'
+      model: 'iPhone 5'
+      device: 'smartphone'
+    - regex: '(?:Apple-)?iPhone5[C,][34]'
+      model: 'iPhone 5c'
+      device: 'smartphone'
+    - regex: '(?:Apple-)?iPhone6[C,][12]'
+      model: 'iPhone 5s'
+      device: 'smartphone'
+    - regex: '(?:Apple-)?iPhone7[C,]1'
+      model: 'iPhone 6 Plus'
+      device: 'smartphone'
+    - regex: '(?:Apple-)?iPhone7[C,]2'
+      model: 'iPhone 6'
+      device: 'smartphone'
+
+    # specific tablet devices
+    - regex: '(?:Apple-)?iPad1[C,]1'
+      model: 'iPad'
+      device: 'tablet'
+    - regex: '(?:Apple-)?iPad2[C,][1234]'
+      model: 'iPad 2'
+      device: 'tablet'
+    - regex: '(?:Apple-)?iPad2[C,][567]'
+      model: 'iPad Mini'
+      device: 'tablet'
+    - regex: '(?:Apple-)?iPad3[C,][123]'
+      model: 'iPad 3'
+      device: 'tablet'
+    - regex: '(?:Apple-)?iPad3[C,][456]'
+      model: 'iPad 4'
+      device: 'tablet'
+    - regex: '(?:Apple-)?iPad4[C,][123]'
+      model: 'iPad Air'
+      device: 'tablet'
+    - regex: '(?:Apple-)?iPad4[C,][456]'
+      model: 'iPad Mini 2'
+      device: 'tablet'
+    - regex: '(?:Apple-)?iPad4[C,][789]'
+      model: 'iPad Mini 3'
+      device: 'tablet'
+    - regex: '(?:Apple-)?iPad5[C,][34]'
+      model: 'iPad Air 2'
+
+
+    - regex: 'AppleTV'
+      model: 'Apple TV'
+      device: 'tv'
+    - regex: '(?:Apple-)?iPad'
+      model: 'iPad'
+      device: 'tablet'
+    - regex: '(?:Apple-)?iPhone ?(3GS?|4S?|5[CS]?|6(:? Plus)?)?'
+      model: 'iPhone $1'
+      device: 'smartphone'
+
+# micromax
+MicroMax:
+  regex: 'MicroMax[ \-\_]?[a-z0-9]+'
+  device: 'smartphone'
+  models:
+    - regex: 'MicroMax(?:[ \-\_])?(P[a-z0-9]+)'
+      model: '$1'
+      device: 'tablet'
+    - regex: 'MicroMax(?:[ \-\_])?([a-z0-9]+)'
+      model: '$1'
+
+# 3Q
+3Q:
+  regex: '(AC0731B|AC1024C|AC7803C|BC9710AM|EL72B|LC0720C|LC0723B|LC0725B|LC0804B|LC0808B|LC0809B|LC0810C|LC0816C|LC0901D|LC1016C|MT0724B|MT0729B|MT0729D|MT0811B|OC1020A|RC0709B|RC0710B|RC0718C|RC0719H|RC0721B|RC0722C|RC0726B|RC0734H|RC0743H|RC0817C|RC1018C|RC1019G|RC1025F|RC1301C|RC7802F|RC9711B|RC9712C|RC9716B|RC9717B|RC9724C|RC9726C|RC9727F|RC9730C|RC9731C|TS0807B|TS1013B|VM0711A|VM1017A|RC0813C|QS9719D|QS9718C|QS9715F|QS1023H|QS0815C|QS0730C|QS0728C|QS0717D|QS0716D|QS0715C|MT7801C)'
+  device: 'tablet'
+  model: '$1'
+
+# Acer
+Acer:
+  regex: 'acer|a(?:101|110|200|210|211|500|501|510|511|700|701) Build|Android.*V360 Build|A1-830|A1-81[01]|A3-A1[01]|B1-7[12][01]|B1-A71|S5[12]0'
+  device: 'smartphone'
+  models:
+    # explicit tablet models
+    - regex: 'A1-81[01]'
+      model: 'Iconia A'
+      device: 'tablet'
+    - regex: 'A1-830'
+      model: 'Iconia A1'
+      device: 'tablet'
+    - regex: 'A3-A1[01]'
+      model: 'Iconia A3'
+      device: 'tablet'
+    - regex: 'B1-7[12][01]|B1-A71'
+      model: 'Iconia B1'
+      device: 'tablet'
+
+    # explicit smartphone models
+    - regex: 'Android.*V360 Build'
+      model: 'Liquid E1'
+    - regex: 'S510 Build'
+      model: 'Liquid S1'
+    - regex: 'S520 Build'
+      model: 'Liquid S2'
+
+    - regex: 'Acer; ?([^;\)]+)'
+      model: '$1'
+    - regex: 'Acer[ _-]?([^;\)]+) Build'
+      model: '$1'
+    - regex: 'acer[\-_]([a-z0-9]+)'
+      model: '$1'
+    - regex: 'a(101|110|200|210|211|500|501|510|511|700|701) Build'
+      model: 'Iconia Tab A$1'
+      device: 'tablet'
+
+# Airness
+Airness:
+  regex: 'AIRNESS-([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# Alcatel
+Alcatel:
+  regex: 'Alcatel|Alc[a-z0-9]+|One ?Touch'
+  device: 'smartphone'
+  models:
+    - regex: '(?:Alcatel[ _])?One[ _]?Touch[ _]((?:T[0-9]+|TAB[^/;]+|EVO[78](?:HD)?)) Build'
+      device: 'tablet'
+      model: 'One Touch $1'
+    - regex: '(?:Alcatel[ _])?One[ _]?Touch([^/;]*) Build'
+      model: 'One Touch$1'
+    - regex: 'Alcatel UP'
+      model: ''
+    - regex: 'ALCATEL([^/;]+) Build'
+      model: '$1'
+    - regex: 'ALCATEL[ \-]?([^/;\)]+)'
+      model: '$1'
+    - regex: 'ALCATEL_([^/;\)]+)'
+      model: '$1'
+    - regex: 'Alc([a-z0-9]+)'
+      model: '$1'
+
+# Amoi
+Amoi:
+  regex: 'Amoi'
+  device: 'smartphone'
+  models:
+    - regex: 'Amoi[\- /]([a-z0-9]+)'
+      model: '$1'
+    - regex: 'Amoisonic-([a-z0-9]+)'
+      model: '$1'
+
+# Archos
+Archos:
+  regex: 'Archos'
+  device: 'smartphone'
+  models:
+    - regex: 'Archos ?5 Build'
+      device: 'tablet'
+      model: '5'
+    - regex: 'Archos ([^/;]*(?:PAD)[^/;]*) Build'
+      device: 'tablet'
+      model: '$1'
+    - regex: 'Archos ((?:[789]|10)[0-9]?[a-z]* ?(?:G9|G10|Helium|Titanium|Cobalt|Platinum|Xenon|Carbon|Neon|XS|IT)[^/;]*) Build'
+      device: 'tablet'
+      model: '$1'
+    - regex: 'Archos ([a-z0-9 ]+) Build'
+      model: '$1'
+    - regex: 'Archos ([a-z0-9]+)'
+      model: '$1'
+
+# Axxion
+Axxion:
+  regex: 'Axxion ATAB-[0-9]+ Build'
+  device: 'tablet'
+  models:
+    - regex: 'Axxion ATAB-([0-9]+) Build'
+      model: 'ATAB-$1'
+
+# Meu
+MEU:
+  regex: 'MEU ([a-z0-9]+) Build'
+  device: 'smartphone'
+  model: '$1'
+
+# Arnova
+Arnova:
+  regex: 'arnova|AN[0-9]'
+  device: 'tablet'
+  models:
+    - regex: 'Arnova ([^/;]*) Build'
+      model: '$1'
+    - regex: 'AN([0-9][a-z0-9]+)'
+      model: '$1'
+
+# Asus
+Asus:
+  regex: 'Asus|Transformer|TF300T|Slider SL101|PadFone|ME302(?:C|KL)|ME301T|ME371MG|ME17(?:1|2V|3X)|K00[0-9a-z] Build'
+  device: 'smartphone'
+  models:
+    # explicit tablet models
+    - regex: 'ME171 Build'
+      model: 'Eee Pad MeMO 171'
+      device: 'tablet'
+    - regex: 'ME172V'
+      model: 'MeMO Pad'
+      device: 'tablet'
+    - regex: 'ME302C Build'
+      model: 'MeMO Pad FHD 10'
+      device: 'tablet'
+    - regex: 'ME302KL Build'
+      model: 'MeMO Pad FHD 10 LTE'
+      device: 'tablet'
+    - regex: 'ME301T Build'
+      model: 'MeMO Pad Smart 10'
+      device: 'tablet'
+    - regex: 'ME371MG Build'
+      model: 'Fonepad'
+      device: 'tablet'
+    - regex: 'K00U|ME173X Build'
+      model: 'MeMO Pad HD 7'
+      device: 'tablet'
+    - regex: 'K00L Build'
+      model: 'MeMO Pad 8'
+      device: 'tablet'
+    - regex: 'K00S Build'
+      model: 'MeMO Pad HD 7 Dual SIM'
+      device: 'tablet'
+    - regex: 'K00E Build'
+      model: 'Fonepad 7'
+      device: 'tablet'
+    - regex: 'K00Z Build'
+      model: 'Fonepad 7 Dual SIM'
+      device: 'tablet'
+    - regex: 'K00F Build'
+      model: 'MeMO Pad 10'
+      device: 'tablet'
+    - regex: 'K00G Build'
+      model: 'Fonepad Note 6'
+      device: 'tablet'
+    - regex: 'K00C Build'
+      model: 'Transformer Pad TF701T'
+      device: 'tablet'
+    - regex: 'TF300T Build'
+      model: 'Transformer Pad TF300T'
+      device: 'tablet'
+    - regex: 'Slider SL101'
+      model: 'Eee Pad Slider SL101'
+      device: 'tablet'
+
+    # explicit smartphone models
+    - regex: '(?:ASUS_)?T00[IQ]'
+      model: 'ZenFone 4'
+
+    # general detections
+    - regex: 'Asus(?:-|;)?([a-z0-9]+)'
+      model: '$1'
+    - regex: '(PadFone(?: [^;/]+)?) Build'
+      model: '$1'
+    - regex: '(PadFone(?: [a-z0-9]+)?)'
+      model: '$1'
+    - regex: '(?:Asus|Transformer) ((?:Pad |Prime )?TF[0-9a-z]+)'
+      device: 'tablet'
+      model: 'Transformer $1'
+
+# Audiovox
+Audiovox:
+  regex: 'Audiovox|CDM|UTS(?:TARCOM)?\-|audio[a-z0-9\-]+'
+  device: 'smartphone'
+  models:
+    - regex: 'Audiovox[_\-]([a-z0-9\-]+)'
+      model: '$1'
+    - regex: 'CDM(?:-)?([a-z0-9]+)'
+      model: 'CDM-$1'
+    - regex: 'UTS(?:TARCOM)?-([a-z0-9\-]+)'
+      model: 'CDM-$1'
+    - regex: 'audio([a-z0-9\-]+)'
+      model: 'CDM-$1'
+
+# Avvio
+Avvio:
+  regex: 'Avvio[ _]([a-z0-9\-]+)'
+  device: 'smartphone'
+  models:
+    - regex: 'Avvio[ _]PAD'
+      model: 'PAD'
+      device: 'tablet'
+    - regex: 'Avvio[ _]([a-z0-9\-]+)'
+      model: '$1'
+
+#Barnes & Noble
+'Barnes & Noble':
+  regex: 'Nook|BN[TR]V[0-9]+'
+  device: 'tablet'
+  models:
+    - regex: 'Nook([a-z0-9]+)'
+      model: 'Nook $1'
+    - regex: 'Nook[ _]([^/;]+)[ _]Build'
+      model: 'Nook $1'
+    - regex: '(BN[TR]V[0-9]+)'
+      model: 'Nook $1'
+
+# Blu
+Blu:
+  regex: 'blu ([^/;]+) Build'
+  device: 'smartphone'
+  model: '$1'
+
+#BBK
+BBK:
+  regex: 'vivo'
+  device: 'smartphone'
+  models:
+    - regex: 'vivo ([^/;]+) Build'
+      model: 'Vivo $1'
+    - regex: 'vivo_([a-z0-9]+)'
+      model: 'Vivo $1'
+
+# Bird
+Bird:
+  regex: 'BIRD[\-. _]([^;/]+)'
+  device: 'feature phone'
+  models:
+    - regex: 'BIRD[\-. _]([^;/]+) Build'
+      model: '$1'
+    - regex: 'BIRD[\-. _]([^;/]+)_TD'
+      model: '$1'
+    - regex: 'BIRD[\-. _]([^;/]+)'
+      model: '$1'
+
+# Becker
+Becker:
+  regex: 'Becker-([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# Beetel
+Beetel:
+  regex: 'Beetel ([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# BenQ-Siemens
+BenQ-Siemens:
+  regex: 'BENQ-SIEMENS - ([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# BenQ
+BenQ:
+  regex: 'BENQ(?:[ \-])?([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# Bmobile
+Bmobile:
+  regex: 'Bmobile_([a-z0-9]+)'
+  device: 'smartphone'
+  model: '$1'
+
+# bq
+bq:
+  regex: 'bq [^/;]+ Build'
+  device: 'tablet'
+  models:
+    - regex: 'bq (Aquaris[^/;]*) Build'
+      model: '$1'
+      device: 'smartphone'
+    - regex: 'bq ([^/;]+) Build'
+      model: '$1'
+
+# Capitel
+Capitel:
+  regex: 'Capitel-([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# Cat
+Cat:
+  regex: 'Cat ?(tablet|stargate|nova)'
+  device: 'tablet'
+  models:
+    - regex: 'Cat ?(?:tablet)? ?((?:Galactica|Nova|StarGate|PHOENIX)[^/;]*) Build'
+      model: '$1'
+    - regex: 'Cat ?tablet'
+      model: 'Nova'
+
+# Celkon
+Celkon:
+  regex: 'Celkon'
+  device: 'smartphone'
+  models:
+    - regex: 'Celkon[ _*](C[78]20)'
+      model: '$1'
+      device: 'tablet'
+    - regex: 'Celkon[ _*](CT[^;/]+) Build'
+      model: '$1'
+      device: 'tablet'
+    - regex: 'Celkon[ _*]([^;/]+) Build'
+      model: '$1'
+    - regex: 'Celkon[\. _*]([^;/\)]+)[\)/]'
+      model: '$1'
+
+# Cherry Mobile
+'Cherry Mobile':
+  regex: 'Cherry|Flare2X|Fusion Bolt'
+  device: 'smartphone'
+  models:
+    - regex: 'Cherry(?: ?Mobile)?[ _]?([^/;]+) Build'
+      model: '$1'
+    - regex: '(Flare2X)'
+      model: '$1'
+    - regex: '(Fusion Bolt)'
+      model: '$1'
+      device: 'tablet'
+
+# Compal
+Compal:
+  regex: 'Compal-[a-z0-9]+'
+  device: 'feature phone'
+  model: '$1'
+
+# ConCorde
+ConCorde:
+  regex: 'ConCorde ([^/;]+) Build'
+  device: 'smartphone'
+  models:
+    - regex: 'ConCorde Tab ?([^/;]+) Build'
+      model: 'Tab $1'
+      device: 'tablet'
+    - regex: 'ConCorde ReadMan ?([^/;]+) Build'
+      model: 'ReadMan $1'
+      device: 'tablet'
+    - regex: 'ConCorde ([^/;]+) Build'
+      model: '$1'
+
+# Coolpad
+Coolpad:
+  regex: '(?:YL-)?Coolpad'
+  device: 'smartphone'
+  models:
+    - regex: '(?:YL-)?Coolpad[ _-]?([^/;]+) Build'
+      model: '$1'
+    - regex: '(?:YL-)?Coolpad[ _-]?([a-z0-9-]+)'
+      model: '$1'
+
+# Cricket
+Cricket:
+  regex: 'Cricket-([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# Crius
+'Crius Mea':
+  regex: '(Q7A\+?) Build'
+  device: 'tablet'
+  model: '$1'
+
+# Cube
+Cube:
+  regex: 'Cube|(U[0-9]+GT(?:[0-9]|[\-_][a-z]+)|K8GT)'
+  device: 'tablet'
+  models:
+    - regex: '(U[0-9]+GT(?:[0-9]|[\-_][a-z]+))'
+      model: '$1'
+    - regex: '(K8GT)'
+      model: '$1'
+
+# Danew
+Danew:
+  regex: 'Dslide ?([^;/]+) Build'
+  device: 'tablet'
+  model: 'DSlide $1'
+
+# Denver Electronics
+Denver:
+  regex: '(TA[CDQ]-[0-9]+)'
+  device: 'tablet'
+  model: '$1'
+
+# Dell
+Dell:
+  regex: 'Dell'
+  device: 'smartphone'
+  models:
+    - regex: 'Dell ((?:Streak|Venue)[^/;]*) Build'
+      model: '$1'
+      device: 'tablet'
+    - regex: 'Dell; ((?:Streak|Venue)[^;/\)]*)'
+      model: '$1'
+      device: 'tablet'
+    - regex: 'Dell; ([^;/\)]+)'
+      model: '$1'
+    - regex: 'Dell[ _-]([^/;]+) Build'
+      model: '$1'
+
+# Dbtel
+Dbtel:
+  regex: 'DBTEL(?:[\-/])?([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# Dicam
+Dicam:
+  regex: 'DICAM-([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# DoCoMo
+DoCoMo:
+  regex: 'DoCoMo|\;FOMA|KGT/1\.0'
+  device: 'feature phone'
+  models:
+    - regex: 'DoCoMo/[12]\.0[/ ]([a-z0-9]+)'
+      model: '$1'
+    - regex: '([a-z0-9]+)(?:_W)?\;FOMA'
+      model: '$1'
+    - regex: 'KGT/1\.0 ([a-z0-9]+)'
+      model: '$1'
+
+# Doogee
+Doogee:
+  regex: '((?:BIGBOY|COLLO[23]?|DAGGER|DISCOVERY|FIND|HOTWIND|LATTE|MAX|MINT|MOON|PIXELS|RAINBOX|TURBO|VALENCIA|VOYAGER) DG[0-9]+) Build'
+  device: 'smartphone'
+  model: '$1'
+
+# Dopod
+Dopod:
+  regex: 'Dopod(?: )?([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# E-Boda
+E-Boda:
+  regex: 'E-Boda'
+  device: 'smartphone'
+  models:
+    - regex: 'E-Boda ((?:Revo|Izzycomm|Essential|Intelligence|Supreme)[^/;]+) Build'
+      device: 'tablet'
+      model: '$1'
+    - regex: 'E-Boda ([^/;]+) Build'
+      model: '$1'
+
+# Easypix
+Easypix:
+  regex: 'EasyPad|EasyPhone'
+  device: 'smartphone'
+  models:
+    - regex: '(EasyPhone[^/;]+) Build'
+      model: '$1'
+    - regex: '(EasyPad[^/;]+) Build'
+      model: '$1'
+      device: 'tablet'
+
+# Ericy
+Ericy:
+  regex: 'Ericy-([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# Sony Ericsson
+Sony Ericsson:
+  regex: 'Sony ?Ericsson|portalmmm/2\.0 K|(?:WT|LT|SO|ST|SK)[0-9]+[a-z]*[0-9]*(?: Build|\))|X10[ia]v?|E1[05][ai]v?|MT[0-9]{2}[a-z]? Build'
+  device: 'smartphone'
+  models:
+    # explicit smartphone models
+    - regex: '(?:SonyEricsson)?CK13i'
+      model: 'txt'
+    - regex: '(?:SonyEricsson)?CK15[ai]'
+      model: 'txt pro'
+    - regex: '(?:SonyEricsson)?E10[ai]v?'
+      model: 'Xperia X10 mini'
+    - regex: '(?:SonyEricsson)?E15[ai]v?'
+      model: 'Xperia X8'
+    - regex: '(?:SonyEricsson)?LT15[ai]v?'
+      model: 'Xperia arc'
+    - regex: '(?:SonyEricsson)?LT18[ai]v?'
+      model: 'Xperia arc S'
+    - regex: '(?:SonyEricsson)?X10[ai]v?'
+      model: 'Xperia X10'
+
+    - regex: 'SonyEricsson([a-z0-9]+) Build'
+      model: '$1'
+    - regex: 'Sony(?: )?Ericsson ?([a-z0-9\-]+)'
+      model: '$1'
+    - regex: '((?:WT|LT|SO|ST|SK)[0-9]+[a-z]*[0-9]*)(?: Build|\))'
+      model: '$1'
+    - regex: '(MT[0-9]{2}[a-z]?) Build'
+      model: '$1'
+    - regex: 'portalmmm/2.0 K([a-z0-9]+)'
+      model: 'K$1'
+
+# Ericsson
+Ericsson:
+  regex: '(?:Ericsson(?:/ )?[a-z0-9]+)|(?:R380 2.0 WAP1.1)'
+  device: 'feature phone'
+  models:
+    - regex: 'Ericsson(?:/ )?([a-z0-9]+)'
+      model: '$1'
+    - regex: 'R380 2.0 WAP1.1'
+      model: 'R380'
+
+# eTouch
+eTouch:
+  regex: 'eTouch ?([a-z0-9]+)'
+  device: 'smartphone'
+  model: '$1'
+
+# Storex
+Storex:
+  regex: "eZee[^a-z]*Tab ?([^;/]*) Build"
+  device: 'tablet'
+  model: "eZee'Tab$1"
+
+# Evertek
+Evertek:
+  regex: '(Ever(?:Glory|Shine|Miracle|Mellow|Classic|Trendy|Fancy)[^/;]*) Build'
+  device: 'smartphone'
+  model: '$1'
+
+# Ezze
+Ezze:
+  regex: 'EZZE-|EZ[a-z0-9]+'
+  device: 'feature phone'
+  models:
+    - regex: 'EZZE-([a-z0-9]+)'
+      model: '$1'
+    - regex: 'EZ([a-z0-9]+)'
+      model: 'EZ$1'
+
+# Ezio
+Ezio:
+  regex: 'EZIO-([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# Gemini
+Gemini:
+  regex: '(GEM[0-9]+[a-z]*)'
+  device: 'tablet'
+  model: '$1'
+
+# Gigabyte
+Gigabyte:
+  regex: 'GSmart [a-z0-9 ]+ Build|Gigabyte-[a-z0-9]+'
+  device: 'smartphone'
+  models:
+    - regex: '(GSmart [a-z0-9 ]+) Build'
+      model: '$1'
+    - regex: 'Gigabyte-([a-z0-9]+)'
+      model: '$1'
+
+# Gigaset
+Gigaset:
+  regex: 'Gigaset QV(1030|830)'
+  device: 'tablet'
+  model: 'Gigaset QV$1'
+
+# Gionee
+Gionee:
+  regex: 'GIONEE-[a-z0-9]+'
+  device: 'smartphone'
+  models:
+    - regex: 'GIONEE-([a-z0-9]+).*Android'
+      model: '$1'
+    - regex: 'Android.*GIONEE-([a-z0-9]+)'
+      model: '$1'
+    - regex: 'GIONEE-([a-z0-9]+)'
+      model: '$1'
+      device: 'feature phone'
+
+# Google
+Google:
+  regex: 'Nexus|GoogleTV|Glass'
+  device: 'smartphone'
+  models:
+    - regex: 'Glass'
+      model: 'Glass'
+    - regex: 'Galaxy Nexus'
+      model: 'Galaxy Nexus'
+    - regex: '(Nexus (?:S|4|5|6|One))'
+      model: '$1'
+    - regex: '(Nexus (?:7|9|10))'
+      device: 'tablet'
+      model: '$1'
+    - regex: 'GoogleTV'
+      device: 'tv'
+      model: 'GoogleTV'
+
+# Gradiente
+Gradiente:
+  regex: 'GRADIENTE'
+  device: 'feature phone'
+  models:
+    - regex: 'GRADIENTE-([a-z0-9]+)'
+      model: '$1'
+    - regex: 'GRADIENTE ([a-z0-9\-]+)'
+      model: '$1'
+
+# Grundig
+Grundig:
+  regex: 'GR?-TB[0-9]+[a-z]*|GRUNDIG|portalmmm/2\.0 G'
+  device: 'tv'
+  models:
+    - regex: '(GR?-TB[0-9]+[a-z]*)'
+      device: 'tablet'
+      model: '$1'
+    - regex: 'GRUNDIG ([a-z0-9]+)'
+      model: '$1'
+    - regex: 'portalmmm/2\.0 G([a-z0-9]+)'
+      model: 'G$1'
+
+# Haier
+Haier:
+  regex: 'Haier'
+  device: 'smartphone'
+  models:
+    - regex: 'Haier[ _-](H[WT]-[^/;]+) Build'
+      model: '$1'
+    - regex: 'Haier[ _-](H[WT]-[a-z0-9_-]+)'
+      model: '$1'
+    - regex: 'Haier[ _-](sy[0-9]+)'
+      model: '$1'
+    - regex: 'Haier[ _-]([a-z0-9\-]+)'
+      model: '$1'
+      device: 'feature phone'
+
+# Huawei
+Huawei:
+  regex: '(HW-)?Huawei|Ideos|vodafone[a-z0-9]+'
+  device: 'smartphone'
+  models:
+    - regex: '(MediaPad[^/;]*) Build'
+      device: 'tablet'
+      model: '$1'
+    - regex: 'Ideos([^;/]*) Build'
+      model: 'Ideos$1'
+    - regex: 'Huawei[ _-]?([^/;]*) Build'
+      model: '$1'
+    - regex: '(?:HW-)?Huawei(?:/1\.0/0?(?:Huawei))?[_\- /]?([a-z0-9\-_]+)'
+      model: '$1'
+    - regex: 'Huawei; ([a-z0-9 -]+)'
+      model: '$1'
+    - regex: 'vodafone([a-z0-9]+)'
+      model: 'Vodafone $1'
+
+# iBall
+iBall:
+  regex: 'iBall[ _]([^/;]*)[ _]Build'
+  device: 'tablet'
+  model: '$1'
+
+iBerry:
+  regex: 'AUXUS ([^/;]+) Build'
+  device: 'smartphone'
+  models:
+    - regex: 'AUXUS (Core[^/;]+) Build'
+      device: 'tablet'
+      model: '$1'
+    - regex: 'AUXUS ([^/;]+) Build'
+      model: '$1'
+
+# Infinix
+Infinix:
+  regex: 'Infinix'
+  device: 'smartphone'
+  models:
+    - regex: 'Infinix (X[78]00)'
+      device: 'tablet'
+      model: '$1'
+    - regex: 'Infinix (X\d+)'
+      model: '$1'
+    - regex: 'Infinix[ _]([a-z0-9_-]+)'
+      model: '$1'
+
+# Inkti
+Inkti:
+  regex: 'intki[ _]([^/;]*)[ _]Build'
+  device: 'smartphone'
+  model: '$1'
+
+# Innostream
+Innostream:
+  regex: 'INNO([a-z0-9]+)'
+  device: 'feature phone'
+  model: 'INNO$1'
+
+# Inq
+INQ:
+  regex: 'INQ[/ ]'
+  device: 'feature phone'
+  models:
+    - regex: 'INQ/([a-z0-9\-]+)'
+      model: '$1'
+    - regex: 'INQ ([^;/]+) Build'
+      model: '$1'
+      device: 'smartphone'
+
+# Intex
+Intex:
+  regex: 'Intex|(Aqua|Cloud)[ _\.]([^/;\)]+)(?:[ _]Build|(?<!Build)/|\))'
+  device: 'smartphone'
+  models:
+    - regex: 'Intex[ _]([^/;]*)[ _]Build'
+      model: '$1'
+    - regex: '(Aqua|Cloud)[ _\.]([^/;\)]+)(?:[ _]Build|(?<!Build)/|\))'
+      model: '$1 $2'
+    - regex: 'Intex[ _]([a-z0-9_+-]+)'
+      model: '$1'
+
+# i-mate
+i-mate:
+  regex: 'i-mate ([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# i-mobile
+i-mobile:
+  regex: 'i-mobile ?[a-z0-9]+'
+  device: 'feature phone'
+  models:
+    - regex: 'i-mobile (i-note[^/;]*) Build'
+      model: '$1'
+      device: 'tablet'
+    - regex: 'i-mobile ((?:IQ|i-style)[^/;]*) Build'
+      model: '$1'
+      device: 'smartphone'
+    - regex: 'i-mobile(?: )?([a-z0-9\- ]+) Build'
+      model: '$1'
+    - regex: 'i-mobile(?: )?([a-z0-9]+)'
+      model: '$1'
+
+# ikomo
+iKoMo:
+  regex: 'iKoMo ([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# iTel
+iTel:
+  regex: 'itel|iNote'
+  device: 'smartphone'
+  models:
+    - regex: 'iNote ([^/;]*)Build'
+      model: 'iNote $1'
+    - regex: 'iNote_([a-z0-9\-_]+)'
+      model: 'iNote $1'
+    - regex: 'iTel ([^/;]*)Build'
+      model: '$1'
+    - regex: 'iTel_([a-z0-9\-_]*)'
+      model: '$1'
+
+#Jiayu
+Jiayu:
+  regex: '(JY-[a-z0-9]+) Build'
+  device: 'smartphone'
+  model: '$1'
+
+# Jolla
+Jolla:
+  regex: 'Jolla'
+  device: 'smartphone'
+  model: ''
+
+# Kazam
+Kazam:
+  regex: 'Kazam ([^;/]+) Build|Trooper_X[0-9][0-9] Build'
+  device: 'smartphone'
+  models:
+    - regex: 'Trooper_X([0-9])([0-9]) Build'
+      model: 'Trooper X$1.$2'
+    - regex: 'Kazam ([^;/]+) Build'
+      model: '$1'
+
+# KT-Tech
+KT-Tech:
+  regex: '(KM-[a-z0-9]+|EV-[a-z0-9]+) Build'
+  device: 'smartphone'
+  model: '$1'
+
+# kddi
+KDDI:
+  regex: 'kddi-([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+#k-touch
+K-Touch:
+  regex: 'K-Touch[ _][a-z0-9]+'
+  device: 'smartphone'
+  models:
+    - regex: 'K-Touch[ _]([^/;]*)[ _]Build'
+      model: '$1'
+    - regex: 'K-Touch[ _]([a-z0-9]+)'
+      model: '$1'
+
+# kyocera
+Kyocera:
+  regex: 'Kyocera|KWC-|QC-|C5170|C5155|C5215|C6750|C6522N?|S2151'
+  device: 'smartphone'
+  models:
+    # explicit smartphone models
+    - regex: 'C5155'
+      model: 'Rise'
+    - regex: 'C5170'
+      model: 'Hydro'
+    - regex: 'C5215'
+      model: 'Hydro EDGE'
+    - regex: 'C6522N?'
+      model: 'Hydro XTRM'
+    - regex: 'C6750'
+      model: 'Hydro ELITE'
+
+    # explicit feature phone models
+    - regex: 'S2151'
+      model: 'Coast'
+      device: 'feature phone'
+
+    - regex: 'Kyocera-KZ-([a-z0-9]+)'
+      model: 'KZ $1'
+    - regex: 'Kyocera(?:[\-/])?([a-z0-9]+)'
+      model: '$1'
+    - regex: '(?:KWC|QC)-([a-z0-9]+)'
+      model: '$1'
+
+# Lava
+Lava:
+  regex: 'iris[ _]?([^/;]+)(?:\)| Build)'
+  device: 'smartphone'
+  models:
+    - regex: 'iris[ _]?([^/;]+)(?:\)| Build)'
+      model: 'Iris $1'
+
+# lanix
+Lanix:
+  regex: 'LANIX-([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# lct
+LCT:
+  regex: 'LCT_([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# lenco
+Lenco:
+  regex: 'Lenco ([^/;]*) Build'
+  device: 'tablet'
+  model: '$1'
+
+# lenovo
+Lenovo:
+  regex: '(?:LNV-)?Lenovo|IdeaTab'
+  device: 'smartphone'
+  models:
+    - regex: 'Lenovo (B[0-9]+[^/;]*) Build'
+      model: 'IdeaTab $1'
+      device: 'tablet'
+    - regex: 'Lenovo ([^/;]*) Build'
+      model: '$1'
+    - regex: '(?:LNV-|Lenovo-)?Lenovo[ \-_]([a-z0-9_+-]+)'
+      model: '$1'
+    - regex: 'IdeaTab[ \-_]?([a-z0-9]+)'
+      model: 'IdeaTab $1'
+      device: 'tablet'
+
+# lexibook
+Lexibook:
+  regex: '(MFC[0-9]{3}[a-z]{2,})'
+  device: 'tablet'
+  models:
+    # Explicit tablet models
+    - regex: 'MFC191FR'
+      model: 'Tablet Ultra 3 XL'
+    - regex: 'MFC045FR'
+      model: 'TabTab'
+    - regex: 'MFC163FR'
+      model: 'Tablet Master 3'
+    - regex: 'MFC142FR'
+      model: 'Tablet Kids'
+    - regex: 'MFC250FR'
+      model: 'Tablet Junior'
+    - regex: 'MFC270FR'
+      model: 'Tablet Junior Power Touch'
+    - regex: 'MFC280FR'
+      model: 'Tablet Junior 2'
+    - regex: 'MFC156FR'
+      model: 'Tablet One'
+    - regex: 'MFC155FR'
+      model: 'Tablet Master'
+    - regex: 'MFC157FR'
+      model: 'Tablet Master 2'
+    - regex: 'MFC17[05]FR'
+      model: 'Tablet Ultra'
+    - regex: 'MFC375FR'
+      model: 'Tablet Ultra 2'
+    - regex: 'MFC162FR'
+      model: 'Power Tablet'
+    - regex: 'MFC180FR'
+      model: 'Tablet Advanced'
+    - regex: 'MFC181FR'
+      model: 'Tablet Advanced 2'
+    - regex: 'MFC500FR'
+      model: 'Tablet XL'
+    - regex: 'MFC190BBFR'
+      model: 'Barbie Tablet'
+    - regex: 'MFC195DCFR'
+      model: 'Tablet Disney Cars HD'
+    - regex: 'MFC195FUFR'
+      model: 'Furby Tablet'
+    - regex: 'MFC195DPFR'
+      model: 'Tablet Disney Princesse HD'
+    - regex: 'MFC140FR'
+      model: 'LapTab'
+    - regex: 'MFC141FR'
+      model: 'LapTab 2'
+
+    - regex: '(MFC[0-9]{3}[a-z]{2,})'
+      model: '$1'
+
+# lg
+LG:
+  regex: 'LG|portalmmm/2\.0 (?:KE|KG|KP|L3)|VX[0-9]+'
+  device: 'smartphone'
+  models:
+    - regex: 'LGE_DLNA_SDK|NetCast'
+      device: 'tv'
+      model: 'NetCast'
+    - regex: 'LGE(?: |-LG| LG-AX|-)([a-z0-9]+)'
+      model: '$1'
+    - regex: 'LGE;([a-z0-9\-]+)'
+      model: '$1'
+    - regex: 'LG[ _-](V90.*|Optimus[ _-]Pad.*) Build'
+      device: 'tablet'
+      model: '$1'
+    - regex: 'LG(?:/|-LG| |-)?([^/;]*) Build'
+      model: '$1'
+    - regex: 'LG(?:/|-LG| |-)?([a-z0-9]+)'
+      model: '$1'
+    - regex: 'LG; ([a-z0-9 ]+)'
+      model: '$1'
+    - regex: 'portalmmm/2.0 ((?:KE|KG|KP|L3)[a-z0-9]+)'
+      model: '$1'
+    - regex: '(VX[0-9]+)'
+      model: '$1'
+
+# Logicom
+Logicom:
+  regex: '(TAB950|TAB1062|E731|E812|E912|E1031) Build'
+  device: 'tablet'
+  model: '$1'
+
+# microsoft
+Microsoft:
+  regex: 'KIN\.(One|Two)'
+  device: 'feature phone'
+  model: 'Kin $1'
+
+# Konka
+Konka:
+  regex: 'KONKA[_ ]([a-z0-9]+)'
+  device: 'smartphone'
+  models:
+    # Explicit smartphone models
+    - regex: 'E5660S'
+      model: 'Viva 5660s'
+    - regex: 'W830'
+      model: 'Tango 830'
+    - regex: 'W(9[67]0)'
+      model: 'Expose $1'
+    - regex: 'W990'
+      model: 'Tuxedo 990'
+
+    - regex: 'KONKA[_ ]([a-z0-9]+)'
+      device: 'feature phone'
+      model: '$1'
+
+# Karbonn
+Karbonn:
+  regex: '(?:Browser-)?Karbonn'
+  device: 'smartphone'
+  models:
+    - regex: 'Karbonn ([a-z0-9]+) WAP-Browser'
+      model: '$1'
+      device: 'feature phone'
+    - regex: 'WAP Browser-Karbonn ([a-z0-9]+)/'
+      model: '$1'
+      device: 'feature phone'
+    - regex: 'Karbonn_([^;/)]+)'
+      model: '$1'
+    - regex: 'Karbonn ([^;/]+) Build'
+      model: '$1'
+    - regex: 'Karbonn ([^;/]+)/'
+      model: '$1'
+
+# Sagem
+Sagem:
+  regex: 'SAGEM|portalmmm/2.0 (?:SG|my)'
+  device: 'smartphone'
+  models:
+    - regex: 'SAGEM-(my[a-z0-9-]+)'
+      model: '$1'
+      device: 'feature phone'
+    - regex: 'SAGEM ([a-z0-9]+)'
+      model: '$1'
+    - regex: 'SAGEM-([a-z0-9\-]+)'
+      model: '$1'
+    - regex: 'portalmmm/2.0 ((?:SG|my)[a-z0-9]+)'
+      model: '$1'
+
+# Coby Kyros
+Coby Kyros:
+  regex: '(MID(?:1024|1125|1126|1045|1048|1060|1065|4331|7012|7015A?|7016|7022|7032|7035|7036|7042|7047|7048|7052|7065|7120|8024|8042|8048|8065|8125|8127|8128|9724|9740|9742)) Build'
+  device: 'tablet'
+  model: '$1'
+
+# Mpman
+Mpman:
+  regex: '(?:MPQC|MPDC)[0-9]+|PH(?:150|340|350|360|451|500|520)|(?:MID(?:7C|74C|82C|84C|801|811|701|711|170|77C|43C|102C|103C|104C|114C)|MP(?:843|717|718|1010|7007|7008|843|888|959|969)|MGP7) Build'
+  device: 'tablet'
+  models:
+    - regex: '((?:MPQC|MPDC)[0-9]+[^/;]+) Build'
+      model: '$1'
+    - regex: '(MID(?:7C|74C|82C|84C|801|811|701|711|170|77C|43C|102C|103C|104C|114C)|MP(?:843|717|718|1010|7007|7008|843|888|959|969)|MGP7) Build'
+      model: '$1'
+    - regex: '(PH(?:150|340|350|360|451|500|520))'
+      model: '$1'
+      device: 'smartphone'
+
+
+# Manta Multimedia
+Manta Multimedia:
+  regex: '(MID(?:06[SN]|08[S]?|12|13|14|15|701|702|703|704|705(?:DC)?|706[AS]?|707|708|709|711|712|714|717|781|801|802|1001|1002|1003|1004(?: 3G)?|1005|7802|9701|9702)) Build'
+  device: 'tablet'
+  model: '$1'
+
+#Medion
+Medion:
+  regex: 'Medion|(?:MD_)?LIFETAB'
+  device: 'smartphone'
+  models:
+    - regex: '(?:MD_)?LIFETAB_([a-z0-9]+)'
+      device: 'tablet'
+      model: 'Lifetab $1'
+    - regex: 'Medion(?: Smartphone)? ([^/;]+) Build'
+      model: '$1'
+
+# Memup
+Memup:
+  regex: 'SlidePad ?([^;/]*) Build'
+  device: 'tablet'
+  model: 'SlidePad $1'
+
+# mio
+Mio:
+  regex: 'MIO(?:/)?([a-z0-9]+)'
+  device: 'smartphone'
+  model: '$1'
+
+# mitsubishi
+Mitsubishi:
+  regex: 'MITSU|portalmmm/[12]\.0 M'
+  device: 'feature phone'
+  models:
+    - regex: 'MITSU/[a-z0-9.]+ \(([a-z0-9]+)\)'
+      model: '$1'
+    - regex: 'MITSU[ \-]?([a-z0-9]+)'
+      model: '$1'
+    - regex: 'portalmmm/[12]\.0 (M[a-z0-9]+)'
+      model: '$1'
+
+# Mobistel
+Mobistel:
+  regex: '(Cynus [^/;]+) Build'
+  device: 'smartphone'
+  model: '$1'
+
+# motorola
+Motorola:
+  regex: 'MOT|(?<!AN)DROID ?(?:Build|[a-z0-9]+)|portalmmm/2.0 (?:E378i|L6|L7|v3)|XOOM [^;/]*Build|(?:XT|MZ|MB|ME)[0-9]{3,4}[a-z]?(?:\(Defy\))?(?: Build|\))'
+  device: 'smartphone'
+  models:
+    # Explicit feature phone models
+    - regex: 'MOT-V360'
+      model: 'V360'
+      device: 'feature phone'
+
+    # Explicit smartphone models
+    - regex: '(?:MOT-|Motorola-)?XT300'
+      model: 'Spice'
+    - regex: '(?:MOT-|Motorola-)?XT30[35]'
+      model: 'Motosmart ME'
+    - regex: '(?:MOT-|Motorola-)?XT31[16]'
+      model: 'Fire'
+    - regex: '(?:MOT-|Motorola-)?XT32[01]'
+      model: 'Defy Mini'
+    - regex: '(?:MOT-|Motorola-)?XT3(?:89|90)'
+      model: 'Motosmart'
+    - regex: '(?:MOT-|Motorola-)?XT502'
+      model: 'Quench'
+    - regex: '(?:MOT-|Motorola-)?XT531'
+      model: 'Fire XT'
+    - regex: '(?:MOT-|Motorola-)?XT535'
+      model: 'Defy'
+    - regex: '(?:MOT-|Motorola-)?XT55[567]C?'
+      model: 'Defy XT'
+    - regex: '(?:MOT-|Motorola-)?XT603'
+      model: 'Admiral'
+    - regex: '(?:MOT-|Motorola-)?XT610'
+      model: 'Droid Pro'
+    - regex: '(?:MOT-|Motorola-)?XT615'
+      model: 'Motoluxe'
+    - regex: '(?:MOT-|Motorola-)?XT621'
+      model: 'Primus'
+    - regex: '(?:MOT-|Motorola-)?XT626'
+      model: 'IronRock'
+    - regex: '(?:MOT-|Motorola-)?XT682'
+      model: 'Atrix'
+    - regex: '(?:MOT-|Motorola-)?XT685'
+      model: 'Motoluxe Dual-SIM'
+    - regex: '(?:MOT-|Motorola-)?XT687'
+      model: 'Atrix TV'
+    - regex: '(?:MOT-|Motorola-)?XT720'
+      model: 'Milestone'
+    - regex: '(?:MOT-|Motorola-)?XT800W'
+      model: 'Glam'
+    - regex: '(?:MOT-|Motorola-)?XT860'
+      model: 'Milestone 3'
+    - regex: '(?:MOT-|Motorola-)?XT881'
+      model: 'Electrify 2'
+    - regex: '(?:MOT-|Motorola-)?XT882'
+      model: 'Moto XT882'
+    - regex: '(?:MOT-|Motorola-)?XT88[56]'
+      model: 'Droid RAZR V'
+    - regex: '(?:MOT-|Motorola-)?XT890'
+      model: 'Droid RAZR i'
+    - regex: '(?:MOT-|Motorola-)?XT894'
+      model: 'Droid 4'
+    - regex: '(?:MOT-|Motorola-)?XT897'
+      model: 'Photon Q'
+    - regex: '(?:MOT-|Motorola-)?XT901'
+      model: 'Electrify M'
+    - regex: '(?:MOT-|Motorola-)?XT90[567]'
+      model: 'Droid RAZR M'
+    - regex: '(?:MOT-|Motorola-)?XT910S?'
+      model: 'Droid RAZR'
+    - regex: '(?:MOT-|Motorola-)?XT91[4568]'
+      model: 'Droid RAZR D1'
+    - regex: '(?:MOT-|Motorola-)?XT9(?:19|20)'
+      model: 'Droid RAZR D3'
+    - regex: '(?:MOT-|Motorola-)?XT925'
+      model: 'Droid RAZR HD'
+    - regex: '(?:MOT-|Motorola-)?XT1022'
+      model: 'Moto E'
+    - regex: '(?:MOT-|Motorola-)?XT1030'
+      model: 'Droid Mini'
+    - regex: '(?:MOT-|Motorola-)?XT10(?:28|3[1234])'
+      model: 'Moto G'
+    - regex: '(?:MOT-|Motorola-)?XT10(?:49|5[23568]|60)'
+      model: 'Moto X'
+    - regex: '(?:MOT-|Motorola-)?XT1080'
+      model: 'Droid Ultra'
+
+    - regex: 'Motorola[ _\-]([a-z0-9]+)'
+      model: '$1'
+    - regex: 'MOTORAZR[ _\-]([a-z0-9]+)'
+      model: 'RAZR $1'
+    - regex: 'MOTORIZR[ _\-]([a-z0-9]+)'
+      model: 'RIZR $1'
+    - regex: 'MOT[O]?[_\-]?([a-z0-9.]+)'
+      model: '$1'
+    - regex: '(?<!AN)DROID ?([a-z0-9 ]*) Build'
+      model: 'DROID $1'
+    - regex: '(?<!AN)DROID ?([a-z0-9]+)'
+      model: 'DROID $1'
+    - regex: 'portalmmm/2.0 ((?:E378i|L6|L7|V3)[a-z0-9]+)'
+      model: '$1'
+    - regex: '(XOOM [^;/]*)Build'
+      device: 'tablet'
+      model: '$1'
+    - regex: '(MZ[0-9]{3}) Build'
+      device: 'tablet'
+      model: '$1'
+    - regex: '((?:ME|MB|XT)[0-9]{3,4}(?:\(Defy\))?) Build'
+      model: '$1'
+
+# myphone
+MyPhone:
+  regex: '(?:MyPhone|MyPad) .+ Build'
+  device: 'smartphone'
+  models:
+    - regex: 'MyPad (.+) Build'
+      model: 'MyPad $1'
+      device: 'tablet'
+    - regex: 'MyPhone (.+) Build'
+      model: '$1'
+
+# nec
+NEC:
+  regex: 'NEC|KGT/2\.0|portalmmm/1\.0 (?:DB|N)|(?:portalmmm|o2imode)/2.0[ ,]N'
+  device: 'smartphone'
+  models:
+    - regex: '(?:NEC-|KGT/2\.0 )([a-z0-9]+)'
+      model: '$1'
+    - regex: 'portalmmm/1\.0 ((?:DB|N)[a-z0-9]+)'
+      model: '$1'
+    - regex: '(?:portalmmm|o2imode)/2\.0[ ,](N[a-z0-9]+)'
+      model: '$1'
+
+# newgen
+Newgen:
+  regex: 'NEWGEN\-([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# ngm
+NGM:
+  regex: 'NGM_[a-z0-9]+|(Forward|Dynamic)[ _][^/;]+(?:Build|/)'
+  device: 'smartphone'
+  models:
+    - regex: '((?:Forward|Dynamic)[ _][^/;]+) Build'
+      model: '$1'
+    - regex: '((?:Forward|Dynamic)[ _][^/;]+)/'
+      model: '$1'
+    - regex: 'NGM_([a-z0-9]+)'
+      model: '$1'
+
+# nexian
+Nexian:
+  regex: 'S?Nexian'
+  device: 'smartphone'
+  models:
+    - regex: 'S?Nexian[ ]?([a-z0-9\-]+)'
+      model: '$1'
+    - regex: 'S?Nexian-([a-z0-9]+)'
+      model: '$1'
+
+# o2
+O2:
+  regex: 'Xda|O2[ \-]|COCOON'
+  device: 'smartphone'
+  models:
+    - regex: '(Xda[ _][a-z0-9_]+)'
+      model: '$1'
+    - regex: '(COCOON)'
+      model: '$1'
+    - regex: 'O2 ([a-z0-9 ]+)'
+      model: '$1'
+    - regex: 'O2-([a-z0-9]+)'
+      model: '$1'
+
+# onda
+Onda:
+  regex: 'Onda'
+  device: 'smartphone'
+  models:
+    # explicit tablet models
+    - regex: 'ONDA MID'
+      model: 'MID'
+      device: 'tablet'
+
+    - regex: '([a-z0-9]+)[ _]Onda'
+      model: '$1'
+    - regex: 'Onda ([a-z0-9]+)'
+      model: '$1'
+
+# oppo
+OPPO:
+  regex: 'OPPO[ _]?([a-z0-9]+)|X9006'
+  device: 'smartphone'
+  models:
+    - regex: 'OPPO[ _]?([a-z0-9]+)'
+      model: '$1'
+    - regex: 'X9006'
+      model: 'Find 7a'
+
+# Opsson
+Opsson:
+  regex: 'Opsson ([^/;]+) Build'
+  device: 'smartphone'
+  model: '$1'
+
+# orange
+Orange:
+  regex: 'SPV[ \-]?([a-z0-9]+)|Orange ([^/;]+) Build'
+  device: 'smartphone'
+  models:
+    - regex: 'Orange ([^/;]+) Build'
+      model: '$1'
+    - regex: 'SPV[ \-]?([a-z0-9]+)'
+      model: 'SPV $1'
+
+# Oysters
+Oysters:
+  regex: 'Oysters'
+  device: 'tablet'
+  models:
+    - regex: 'Oysters ((?:Arctic|Indian|Atlantic|Pacific)[^/;]+) Build'
+      device: 'smartphone'
+      model: '$1'
+    - regex: 'Oysters ([^/;]+) Build'
+      model: '$1'
+
+# panasonic
+Panasonic:
+  regex: 'Panasonic'
+  device: 'smartphone'
+  models:
+    - regex: 'Panasonic MIL DLNA'
+      device: 'tv'
+      model: 'Viera Cast'
+    - regex: 'Panasonic[ \-]?([a-z0-9]+)'
+      model: '$1'
+    - regex: 'portalmmm/2.0 (P[a-z0-9]+)'
+      model: '$1'
+
+# philips
+Philips:
+  regex: 'Philips'
+  device: 'smartphone'
+  models:
+    - regex: 'Philips-FISIO ([a-z0-9]+)'
+      model: 'Fisio $1'
+    - regex: 'Philips[ ]?([a-z0-9]+)'
+      model: '$1'
+    - regex: 'Philips-([a-z0-9\-@]+)'
+      model: '$1'
+
+# phoneOne
+phoneOne:
+  regex: 'phoneOne[ \-]?([a-z0-9]+)'
+  device: 'smartphone'
+  model: '$1'
+
+# Rover
+Rover:
+  regex: 'Rover ([0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# Siemens
+Siemens:
+  regex: 'SIEMENS|SIE-|portalmmm/2\.0 SI|S55|SL45i'
+  device: 'smartphone'
+  models:
+    - regex: 'SIEMENS[ \-]([a-z0-9]+)'
+      model: '$1'
+    - regex: 'SIE(?:MENS )?[\-]?([a-z0-9]+)'
+      model: '$1'
+    - regex: '(S55|SL45i)'
+      model: '$1'
+    - regex: 'portalmmm/2.0 (SI[a-z0-9]+)'
+      model: '$1'
+
+# Samsung
+Samsung:
+  regex: 'SAMSUNG|SC-(?:02C|04E|01F)|S(?:CH|GH|PH|EC|AM|HV|HW|M)-|SMART-TV|GT-|Galaxy|(?:portalmmm|o2imode)/2\.0 [SZ]|sam[rua]'
+  device: 'smartphone'
+  models:
+    # explicit tablet models
+    - regex: '(?:SAMSUNG-)?GT-P1000M?'
+      device: 'tablet'
+      model: 'GALAXY Tab'
+    - regex: '(?:SAMSUNG-)?GT-P3100B?'
+      device: 'tablet'
+      model: 'GALAXY Tab 2 7"'
+    - regex: '(?:SAMSUNG-)?GT-P311[03]'
+      device: 'tablet'
+      model: 'GALAXY Tab 2 7" WiFi'
+    - regex: '(?:SAMSUNG-)?GT-P5100'
+      device: 'tablet'
+      model: 'GALAXY Tab 2 10.1"'
+    - regex: '(?:SAMSUNG-)?GT-P511[03]'
+      device: 'tablet'
+      model: 'GALAXY Tab 2 10.1" WiFi'
+    - regex: '(?:SAMSUNG-)?GT-P5200'
+      device: 'tablet'
+      model: 'GALAXY Tab 3 10.1"'
+    - regex: '(?:SAMSUNG-)?GT-P5210'
+      device: 'tablet'
+      model: 'GALAXY Tab 3 10.1" WiFi'
+    - regex: '(?:SAMSUNG-)?GT-P5220'
+      device: 'tablet'
+      model: 'GALAXY Tab 3 10.1" LTE'
+    - regex: '(?:SAMSUNG-)?GT-P6200'
+      device: 'tablet'
+      model: 'GALAXY Tab 7" Plus'
+    - regex: '(?:SAMSUNG-)?GT-P6201'
+      device: 'tablet'
+      model: 'GALAXY Tab 7" Plus N'
+    - regex: '(?:SAMSUNG-)?GT-P6810'
+      device: 'tablet'
+      model: 'GALAXY Tab 7.7"'
+    - regex: '(?:SAMSUNG-)?GT-P7100'
+      device: 'tablet'
+      model: 'GALAXY Tab 10.1v'
+    - regex: '(?:SAMSUNG-)?GT-P7500'
+      device: 'tablet'
+      model: 'GALAXY Tab 10.1" P7500'
+    - regex: '(?:SAMSUNG-)?SM-P600'
+      device: 'tablet'
+      model: 'GALAXY Note 10.1" 2014 Edition WiFi'
+    - regex: '(?:SAMSUNG-)?SM-P60[12]'
+      device: 'tablet'
+      model: 'GALAXY Note 10.1" 2014 Edition'
+    - regex: '(?:SAMSUNG-)?SM-P605'
+      device: 'tablet'
+      model: 'GALAXY Note 10.1" 2014 Edition LTE'
+    - regex: '(?:SAMSUNG-)?SM-P900'
+      device: 'tablet'
+      model: 'GALAXY NotePRO 12.2" WiFi'
+    - regex: '(?:SAMSUNG-)?SM-P901'
+      device: 'tablet'
+      model: 'GALAXY NotePRO 12.2"'
+    - regex: '(?:SAMSUNG-)?SM-P905'
+      device: 'tablet'
+      model: 'GALAXY NotePRO 12.2" LTE'
+    - regex: '(?:SAMSUNG-)?SM-T110'
+      device: 'tablet'
+      model: 'GALAXY Tab 3 7.0" Lite WiFi'
+    - regex: '(?:SAMSUNG-)?SM-T111'
+      device: 'tablet'
+      model: 'GALAXY Tab 3 7.0" Lite'
+    - regex: '(?:SAMSUNG-)?SM-T2105'
+      device: 'tablet'
+      model: 'GALAXY Tab 3 7.0" Kids'
+    - regex: '(?:SAMSUNG-)?SM-T210R?'
+      device: 'tablet'
+      model: 'GALAXY Tab 3 7.0" WiFi'
+    - regex: '(?:SAMSUNG-)?SM-T21(?:1|7[AS])'
+      device: 'tablet'
+      model: 'GALAXY Tab 3 7.0"'
+    - regex: '(?:SAMSUNG-)?SM-T230(?:NU)?'
+      device: 'tablet'
+      model: 'GALAXY Tab 4 7.0" WiFi'
+    - regex: '(?:SAMSUNG-)?SM-T310'
+      device: 'tablet'
+      model: 'GALAXY Tab 3 8.0" WiFi'
+    - regex: '(?:SAMSUNG-)?SM-T311'
+      device: 'tablet'
+      model: 'GALAXY Tab 3 8.0"'
+    - regex: '(?:SAMSUNG-)?SM-T315'
+      device: 'tablet'
+      model: 'GALAXY Tab 3 8.0" LTE'
+    - regex: '(?:SAMSUNG-)?SM-T520'
+      device: 'tablet'
+      model: 'GALAXY TabPRO 10.1" WiFi'
+    - regex: '(?:SAMSUNG-)?SM-T320'
+      device: 'tablet'
+      model: 'GALAXY TabPRO 8.4" WiFi'
+    - regex: '(?:SAMSUNG-)?SM-T325'
+      device: 'tablet'
+      model: 'GALAXY TabPRO 8.4" LTE'
+    - regex: '(?:SAMSUNG-)?SM-T525'
+      device: 'tablet'
+      model: 'GALAXY TabPRO 10.1" LTE'
+    - regex: '(?:SAMSUNG-)?SM-T530(?:NU)?'
+      device: 'tablet'
+      model: 'GALAXY Tab 4 10.1" WiFi'
+    - regex: '(?:SAMSUNG-)?SM-T900'
+      device: 'tablet'
+      model: 'GALAXY TabPRO 12.2" WiFi'
+
+    # explicit smartphone models
+    - regex: '(?:SAMSUNG-)?SM-C101'
+      model: 'GALAXY S4 zoom'
+    - regex: '(?:SAMSUNG-)?SM-C115'
+      model: 'GALAXY K zoom'
+    - regex: '(?:SAMSUNG-)?SM-G350'
+      model: 'GALAXY CORE Plus'
+    - regex: '(?:SAMSUNG-)?SM-G386F'
+      model: 'GALAXY CORE LTE'
+    - regex: '(?:SAMSUNG-)?SM-G3815'
+      model: 'GALAXY EXPRESS II'
+    - regex: '(?:SAMSUNG-)?SM-G9009D'
+      model: 'GALAXY S5 Dual-SIM'
+    - regex: '(?:SAMSUNG-)?SM-G900'
+      model: 'GALAXY S5'
+    - regex: '(?:SAMSUNG-)?SM-N7502'
+      model: 'Galaxy Note 3 Neo Duos'
+    - regex: '(?:SAMSUNG-)?SM-N750[L50]?'
+      model: 'Galaxy Note 3 Neo'
+    - regex: '(?:SAMSUNG-)?SM-N9002'
+      model: 'GALAXY Note 3 Duos'
+    - regex: '(?:SAMSUNG-)?SM-N900(?:[05689][VQ]?|[AKLPSTV]|W8)?'
+      model: 'GALAXY Note 3'
+    - regex: '(?:SAMSUNG-)?SM-N910'
+      model: 'GALAXY Note 4'
+    - regex: '(?:SAMSUNG-)?SM-N915'
+      model: 'GALAXY Note 4 Edge'
+
+    # general detections
+    - regex: '(?:SAMSUNG-)?(GT-(P|N8|N5)[0-9]+[a-z]?)'
+      device: 'tablet'
+      model: '$1'
+    - regex: 'SC-02C'
+      model: 'GALAXY S II'
+    - regex: 'SC-01F'
+      model: 'GALAXY Note 3'
+    - regex: 'SC-04E'
+      model: 'GALAXY S4'
+    - regex: '(?:SAMSUNG-)?((?:SM-[TNP]|GT-P)[a-z0-9_-]+)'
+      device: 'tablet'
+      model: '$1'
+    - regex: '((?:SCH|SGH|SPH|SHV|SHW|GT|SM)-[a-z0-9_-]+)'
+      model: '$1'
+    - regex: 'SAMSUNG[\-][ ]?([a-z0-9]+[\-_][a-z0-9]+)'
+      model: '$1'
+    - regex: 'SAMSUNG;[ ]?([a-z0-9]+[\-_][a-z0-9]+)'
+      model: '$1'
+    - regex: 'SAMSUNG[ _/-]?([a-z0-9\-]+)'
+      model: '$1'
+    - regex: 'SAMSUNG;[ ]?([a-z0-9 ]+)'
+      model: '$1'
+    - regex: 'SEC-([a-z0-9]+)'
+      model: '$1'
+    - regex: 'SAM-([a-z0-9]+)'
+      model: 'SCH-$1'
+    - regex: 'SMART-TV'
+      device: 'tv'
+      model: 'Smart TV'
+    - regex: 'Galaxy ([^/;]+) Build'
+      model: 'GALAXY $1'
+    - regex: 'Galaxy ([a-z0-9]+)'
+      model: 'GALAXY $1'
+    - regex: '(?:portalmmm|o2imode)/2\.0 ([SZ][a-z0-9]+)'
+      model: '$1'
+    - regex: 'sam([rua][0-9]+)'
+      model: 'SCH-$1'
+
+# SuperSonic
+SuperSonic:
+  regex: '(SC-[0-9]+[a-z]+)'
+  device: 'tablet'
+  model: '$1'
+
+# Sumvision
+Sumvision:
+  regex: '(Cyclone [^/;]+) Build'
+  device: 'tablet'
+  model: '$1'
+
+# pantech
+Pantech:
+  regex: 'Pantech|P[GN]-|PT-[a-z0-9]{3,}|TX[T]?[0-9]+|IM-[a-z0-9]+ Build|ADR910L'
+  device: 'smartphone'
+  models:
+    # explicit smartphone models
+    - regex: 'ADR910L'
+      model: 'Star Q'
+
+    - regex: 'Pantech[ \-]?([a-z0-9]+)'
+      model: '$1'
+    - regex: 'Pantech_([a-z0-9\-]+)'
+      model: '$1'
+    - regex: '(P[GTN]-[a-z0-9]+)'
+      model: '$1'
+    - regex: '(TX[T]?[0-9]+)'
+      model: '$1'
+    - regex: '(IM-[a-z0-9]+) Build'
+      model: '$1'
+
+#Polaroid
+Polaroid:
+  regex: 'Polaroid|(?:PMID|MIDC)[0-9a-z]+ Build|MID(?:1014|0714)'
+  device: 'tablet'
+  models:
+    - regex: '(MID(?:1014|0714))'
+      model: '$1'
+    - regex: '((?:PMID|MIDC)[0-9a-z]+) Build'
+      model: '$1'
+    - regex: 'Polaroid'
+      model: ''
+
+# PolyPad
+PolyPad:
+  regex: 'POLY ?PAD'
+  device: 'tablet'
+  models:
+    - regex: 'POLY ?PAD[_ \.]([a-z0-9]+) Build'
+      model: '$1'
+    - regex: 'POLY ?PAD[_\.]([a-z0-9]+)'
+      model: '$1'
+
+# Positivo
+Positivo:
+  regex: 'YPY_S450'
+  device: 'smartphone'
+  models:
+    - regex: 'YPY_S450'
+      model: 'YPY S450'
+
+# Prestigio
+Prestigio:
+  regex: '(?:PMP|PAP)[0-9]+[a-z0-9_]+ Build'
+  device: 'tablet'
+  models:
+    - regex: '(PMP[0-9]+[a-z0-9_]+) Build'
+      model: '$1'
+    - regex: '(PAP[0-9]+[a-z0-9_]+) Build'
+      model: '$1'
+      device: 'smartphone'
+
+# Sanyo
+Sanyo:
+  regex: 'Sanyo|MobilePhone[ ;]'
+  device: 'feature phone'
+  models:
+    # explicit feature phone models
+    - regex: 'SCP-?6750'
+      model: 'Katana Eclipse X'
+    - regex: 'SCP-?6760'
+      model: 'Incognito'
+    - regex: 'SCP-?6780'
+      model: 'Innuendo'
+
+    - regex: 'SANYO[ \-_]([a-z0-9\-]+)'
+      model: '$1'
+    - regex: 'MobilePhone ([a-z0-9\-]+)'
+      model: '$1'
+
+# Qilive
+Qilive:
+  regex: 'Qilive [0-9][^;/]*'
+  device: 'smartphone'
+  models:
+    - regex: 'Qilive ([0-5][^;/]*) Build'
+      model: '$1'
+    - regex: 'Qilive ([0-5][^;/]*)/'
+      model: '$1'
+    - regex: 'Qilive ([6-9][^;/]*) Build'
+      model: '$1'
+      device: 'tablet'
+    - regex: 'Qilive ([6-9][^;/]*)/'
+      model: '$1'
+      device: 'tablet'
+
+# Quechua
+Quechua:
+  regex: 'Quechua Phone 5'
+  device: 'smartphone'
+  model: 'Quechua Phone 5'
+
+# Ramos
+Ramos:
+  regex: 'Ramos ?([^/;]+) Build'
+  device: 'tablet'
+  model: '$1'
+
+# Sendo
+Sendo:
+  regex: 'Sendo([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# Spice
+Spice:
+  regex: 'Spice'
+  device: 'smartphone'
+  models:
+    - regex: 'Spice[ _-]?([^/;]+)(?:[\)]| Build)'
+      model: '$1'
+    - regex: 'Spice[ _-]?([^/;]+)(?:/|$)'
+      model: '$1'
+
+# Sharp
+Sharp:
+  regex: 'SHARP|SBM|SH-[0-9]+[a-z]? Build|AQUOS'
+  device: 'smartphone'
+  models:
+    # explicit smartphone models
+    - regex: 'SH-02E'
+      model: 'Aquos Phone Zeta'
+    - regex: 'SH06D'
+      model: 'Aquos Phone SH-06D'
+
+    # explicit tablet models
+    - regex: 'SH-08E'
+      device: 'tablet'
+      model: 'Sharp Aquos Pad'
+
+    - regex: 'SHARP-AQUOS|AQUOSBrowser'
+      device: 'tv'
+      model: 'Aquos Net Plus'
+    - regex: 'SHARP[ \-]([a-z0-9\-]+)'
+      model: '$1'
+    - regex: '(?:SHARP|SBM)([a-z0-9]+)'
+      model: '$1'
+    - regex: '(SH-[0-9]+[a-z]?) Build'
+      model: '$1'
+
+# Softbank
+Softbank:
+  regex: 'Softbank|J-PHONE'
+  device: 'smartphone'
+  models:
+    - regex: 'Softbank/[12]\.0/([a-z0-9]+)'
+      model: '$1'
+    - regex: '([a-z0-9]+);Softbank;'
+      model: '$1'
+    - regex: 'J-PHONE/[0-9]\.[0-9]/([a-z0-9\-]+)'
+      model: '$1'
+
+# Sony
+Sony:
+  regex: 'Sony(?! ?Ericsson)|SGP|Xperia|C1[569]0[45]|C2[01]0[45]|C2305|C530[236]|C5502|C6[56]0[236]|C6616|C68(?:0[26]|[34]3)|C69(?:0[236]|16|43)|D200[45]|D21(?:0[45]|14)|D22(?:0[236]|12|43)|D230[2356]|D530[36]|D5322|D5503|D65(?:0[23]|43)|LT22i|XL39H'
+  device: 'smartphone'
+  models:
+    # explicit smartphone models
+    - regex: '(?:Sony)?C150[45]'
+      model: 'Xperia E'
+    - regex: '(?:Sony)?C160[45]'
+      model: 'Xperia E Dual'
+    - regex: '(?:Sony)?C190[45]'
+      model: 'Xperia M'
+    - regex: '(?:Sony)?C200[45]'
+      model: 'Xperia M Dual'
+    - regex: '(?:Sony)?C210[45]'
+      model: 'Xperia L'
+    - regex: '(?:Sony)?C2305'
+      model: 'Xperia C'
+    - regex: '(?:Sony)?C530[236]'
+      model: 'Xperia SP'
+    - regex: '(?:Sony)?C5502'
+      model: 'Xperia ZR'
+    - regex: '(?:Sony)?C650[236]'
+      model: 'Xperia ZL'
+    - regex: '(?:Sony)?C66(?:0[236]|16)'
+      model: 'Xperia Z'
+    - regex: '(?:Sony)?(?:C68(?:0[26]|[34]3)|XL39H)'
+      model: 'Xperia Z Ultra'
+    - regex: '(?:Sony)?C69(?:0[236]|16|43)'
+      model: 'Xperia Z1'
+    - regex: '(?:Sony)?D200[45]'
+      model: 'Xperia E1'
+    - regex: '(?:Sony)?D21(?:0[45]|14)'
+      model: 'Xperia E1 Dual'
+    - regex: '(?:Sony)?D22(?:0[236]|43)'
+      model: 'Xperia E3'
+    - regex: '(?:Sony)?D2212'
+      model: 'Xperia E3 Dual'
+    - regex: '(?:Sony)?D2302'
+      model: 'Xperia M2 Dual'
+    - regex: '(?:Sony)?D230[356]'
+      model: 'Xperia M2'
+    - regex: '(?:Sony)?D530[36]'
+      model: 'Xperia T2 Ultra'
+    - regex: '(?:Sony)?D5322'
+      model: 'Xperia T2 Ultra Dual'
+    - regex: '(?:Sony)?D5503'
+      model: 'Xperia Z1 Compact'
+    - regex: '(?:Sony)?D65(?:0[23]|43)'
+      model: 'Xperia Z2'
+
+    # explicit tablet models
+    - regex: 'SGP(?:311|312|321) Build'
+      model: 'Xperia Tablet Z'
+      device: 'tablet'
+    - regex: 'SGP(?:511|512|521) Build'
+      model: 'Xperia Tablet Z2'
+      device: 'tablet'
+    - regex: 'SGP(?:6[24]1) Build'
+      model: 'Xperia Tablet Z3 Compact'
+      device: 'tablet'
+    - regex: 'SGPT(?:12|121|122|123|13|131|132|133) Build'
+      model: 'Xperia Tablet S'
+      device: 'tablet'
+
+    # general detections
+    - regex: 'Sony (Tablet[^/;]*) Build'
+      model: '$1'
+      device: 'tablet'
+    - regex: '(SGP[^/;]*) Build'
+      model: '$1'
+      device: 'tablet'
+    - regex: 'Xperia ([^/;]*Tablet[^/;]*) Build'
+      model: 'Xperia $1'
+      device: 'tablet'
+    - regex: 'Xperia ([^;/]+) Build'
+      model: 'Xperia $1'
+    - regex: 'Sony[ ]?([^/;]*) Build'
+      model: '$1'
+    - regex: 'Sony[ ]?([a-z0-9\-]+)'
+      model: '$1'
+
+# Kindle
+Kindle:
+  regex: 'KF(?:OT|TT|JWI|JWA|SOWI|APWI|THWI) Build|Kindle|Silk/\d+\.\d+'
+  device: 'tablet'
+  models:
+    - regex: 'KFTT Build'
+      model: 'Kindle Fire HD'
+    - regex: 'KFJWI Build'
+      model: 'Kindle Fire HD 8.9" WiFi'
+    - regex: 'KFJWA Build'
+      model: 'Kindle Fire HD 8.9" 4G'
+    - regex: 'KFSOWI Build'
+      model: 'Kindle Fire HD 7" WiFi'
+    - regex: 'KFTHWI Build'
+      model: 'Kindle Fire HDX 7" WiFi'
+    - regex: 'KFTHWA Build'
+      model: 'Kindle Fire HDX 7" 4G'
+    - regex: 'KFAPWI Build'
+      model: 'Kindle Fire HDX 8.9" WiFi'
+    - regex: 'KFAPWA Build'
+      model: 'Kindle Fire HDX 8.9" 4G'
+    - regex: 'KFOT|Kindle Fire|Silk/\d+\.\d+'
+      model: 'Kindle Fire'
+    - regex: 'Kindle'
+      model: 'Kindle'
+
+# Symphony
+Symphony:
+  regex: 'SYMPHONY[ \_]([a-z0-9]+)'
+  device: 'smartphone'
+  model: '$1'
+
+# Qtek
+Qtek:
+  regex: 'Qtek[ _]?([a-z0-9]+)'
+  device: 'smartphone'
+  model: '$1'
+
+# T-Mobile
+T-Mobile:
+  regex: 'T-Mobile[ _][a-z0-9 ]+'
+  device: 'smartphone'
+  models:
+    - regex: 'T-Mobile[ _]([a-z0-9_ ]+) Build'
+      model: '$1'
+    - regex: 'T-Mobile[ _]([a-z0-9_ ]+)'
+      model: '$1'
+
+# Tcl
+TCL:
+  regex: 'TCL-([a-z0-9]+)'
+  device: 'smartphone'
+  model: '$1'
+
+# Tecno Mobile
+Tecno Mobile:
+  regex: 'Tecno'
+  device: 'smartphone'
+  models:
+    - regex: 'Tecno ([^;/]+) Build'
+      model: '$1'
+    - regex: 'Tecno_?([a-z0-9_-]+)'
+      model: '$1'
+
+# teXet
+teXet:
+  regex: '(NaviPad [^/;]*) Build'
+  device: 'tablet'
+  model: '$1'
+
+# Telit
+Telit:
+  regex: 'Telit'
+  device: 'feature phone'
+  models:
+    - regex: 'Telit_Mobile_Terminals-([a-z0-9]+)'
+      model: '$1'
+    - regex: 'Telit[\-_]?([a-z0-9]+)'
+      model: '$1'
+
+# Tianyu
+TIANYU:
+  regex: 'TIANYU'
+  device: 'feature phone'
+  models:
+    - regex: 'TIANYU ([a-z0-9]+)'
+      model: '$1'
+    - regex: 'TIANYU-KTOUCH/([a-z0-9]+)'
+      model: '$1'
+
+# Tolino
+Tolino:
+  regex: 'Tolino Tab ([^/;]+) Build'
+  device: 'tablet'
+  model: 'Tolino Tab $1'
+
+# Toplux
+Toplux:
+  regex: 'Toplux ([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+#TVC
+TVC:
+  regex: '(NuclearSX-SP5)'
+  device: 'smartphone'
+  model: 'Nuclear SX-SP5'
+
+# UTStarcom
+UTStarcom:
+  regex: 'utstar[ _-]?([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# ViewSonic
+ViewSonic:
+  regex: 'ViewSonic|VSD[0-9]+ Build'
+  device: 'smart display'
+  models:
+    - regex: 'ViewSonic-ViewPad([a-z0-9]+) Build'
+      model: 'ViewPad $1'
+      device: 'tablet'
+    - regex: '(VSD[0-9]+) Build'
+      model: '$1'
+
+# Vitelcom
+Vitelcom:
+  regex: 'Vitelcom|portalmmm/[12].0 TSM'
+  device: 'feature phone'
+  models:
+    - regex: 'TSM-([a-z0-9]+)'
+      model: '$1'
+    - regex: 'TSM([a-z0-9\-]+)'
+      model: '$1'
+    - regex: 'portalmmm/[12].0 (TSM[a-z0-9 ]+)'
+      model: '$1'
+
+# VK Mobile
+VK Mobile:
+  regex: 'VK[\-]?([a-z0-9 ]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# Vertu
+Vertu:
+  regex: 'Vertu[ ]?([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# Videocon
+Videocon:
+  regex: 'Videocon[_ ]([a-z0-9]+)'
+  device: 'smartphone'
+  model: '$1'
+
+# Voxtel
+Voxtel:
+  regex: 'Voxtel_([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# Wellcom
+WellcoM:
+  regex: 'WELLCOM[ _\-/]([a-z0-9]+)'
+  device: 'smartphone'
+  model: '$1'
+
+# Wiko
+Wiko:
+  regex: '(?:Wiko-)?(?:CINK|IGGY|Stairway|Rainbow|Highway|Darkside|Darkmoon|Darkfull|Darknight|Sublim|Ozzy|Barry)'
+  device: 'smartphone'
+  models:
+    - regex: '(?:Wiko-)?CINK(.*) Build'
+      model: 'Cink$1'
+    - regex: '(?:Wiko-)?CINK[ _-]([a-z0-9]+)'
+      model: 'Cink $1'
+    - regex: '(?:Wiko-)?IGGY(.*) Build'
+      model: 'Iggy$1'
+    - regex: '(?:Wiko-)?IGGY[ _-]([a-z0-9]+)'
+      model: 'Iggy $1'
+    - regex: 'Stairway'
+      model: 'Stairway'
+    - regex: 'Highway'
+      model: 'Highway'
+    - regex: 'Rainbow'
+      model: 'Rainbow'
+    - regex: 'Darkside'
+      model: 'Darkside'
+    - regex: 'Darkmoon'
+      model: 'Darkmoon'
+    - regex: 'Darkfull'
+      model: 'Darkfull'
+    - regex: 'Darknight'
+      model: 'Darknight'
+    - regex: 'Sublim'
+      model: 'Sublim'
+    - regex: 'Ozzy'
+      model: 'Ozzy'
+    - regex: 'Barry'
+      model: 'Barry'
+
+# Wolder
+Wolder:
+  regex: 'miSmart|miTab'
+  device: 'smartphone'
+  models:
+    - regex: 'miSmart[ -_]?([^/]+) Build'
+      model: 'miSmart $1'
+    - regex: 'miTab[ -_]?([^/]+) Build'
+      device: 'tablet'
+      model: 'miTab $1'
+
+# Wonu
+Wonu:
+  regex: 'Wonu ([a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# Woxter
+Woxter:
+  regex: 'Woxter (.+) Build'
+  device: 'tablet'
+  model: '$1'
+
+#Xiaomi
+Xiaomi:
+  regex: '(MI [a-z0-9]+|MI-One[ _]Plus) Build'
+  device: 'smartphone'
+  model: '$1'
+
+#Yuandao
+Yuandao:
+  regex: 'N101[ _]DUAL(?:[ _]CORE)?(?:[ _]?2|\|\|)?(?:[ _]V11)? Build'
+  device: 'tablet'
+  model: 'N101'
+
+# Zonda
+Zonda:
+  regex: '(ZM(?:CK|EM|TFTV|TN)[a-z0-9]+)'
+  device: 'feature phone'
+  model: '$1'
+
+# Toshiba
+Toshiba:
+  regex: 'Toshiba|portalmmm/[12].0 TS'
+  device: 'smartphone'
+  models:
+    - regex: 'Toshiba[ /_\-]?([a-z0-9_ -]+) Build'
+      model: '$1'
+    - regex: 'Toshiba[ /_\-]?([a-z0-9_-]+)'
+      model: '$1'
+    - regex: 'portalmmm/[12].0 (TS[a-z0-9 ]+)'
+      model: '$1'
+
+# Fly
+Fly:
+  regex: 'Fly(?!Flow|touch)|MERIDIAN-'
+  device: 'smartphone'
+  models:
+    - regex: 'Fly[ _\-]?([a-z0-9_]+)/'
+      model: '$1'
+      device: 'feature phone'
+    - regex: 'Flylife[ _\-]?(.*) Build'
+      model: 'Flylife $1'
+      device: 'tablet'
+    - regex: 'Fly[ _\-]?([a-z0-9]+)'
+      model: '$1'
+    - regex: 'MERIDIAN-([a-z0-9]+)'
+      model: '$1'
+
+# Web TV
+Web TV:
+  regex: 'WebTV/(\d+\.\d+)'
+  device: 'tv'
+  model: ''
+
+# Zopo
+Zopo:
+  regex: '(?:ZOPO[_ ])?(ZP[0-9]{2,}[^/;]+) Build'
+  device: 'smartphone'
+  model: '$1'
+
+# ZTE
+ZTE:
+  regex: 'ZTE|Z331|N799D|([a-z0-9]+)_USA_Cricket'
+  device: 'smartphone'
+  models:
+    # Explicit smartphone models
+    - regex: 'N799D'
+      model: 'MTS Blaze 4'
+
+    - regex: '([a-z0-9]+)_USA_Cricket'
+      model: '$1'
+    - regex: 'ZTE[\- ](V98|V96A|V81|V70) Build'
+      model: '$1'
+      device: 'tablet'
+    - regex: 'ZTE[\- ]([a-z0-9\-_ ]+) Build'
+      model: '$1'
+    - regex: 'ZTE-(?:G |G-)?([a-z0-9 _]+)'
+      model: '$1'
+    - regex: 'ZTE[ _]([a-z0-9]+)'
+      model: '$1'
+    - regex: 'Z331'
+      model: 'Z331'
+
+# Symbian to Nokia ??
+# Change name from Nokia to other to not change above Nokia element
+#Nokia:
+#  regex: 'Symbian'
+#  device: 'feature phone'

--- a/spec/device_detector/device_spec.rb
+++ b/spec/device_detector/device_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe DeviceDetector::Device do
+
+  subject(:device) { DeviceDetector::Device.new(user_agent) }
+
+  describe '#name' do
+
+    context 'when models are nested' do
+      let(:user_agent) { 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12B466 [FBDV/iPhone7,2]' }
+
+      it 'should find an Apple iPhone 6' do
+        expect(device.name).to eq('iPhone 6')
+      end
+    end
+
+    context 'when models are NOT nested' do
+      let(:user_agent) { 'AIRNESS-AIR99/REV 2.2.1/Teleca Q03B1' }
+
+      it 'should find an Airness AIR99' do
+        expect(device.name).to eq('AIR99')
+      end
+    end
+
+  end
+
+  describe '#device_type' do
+
+    context 'when models are nested' do
+      let(:user_agent) { 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12B466 [FBDV/iPhone7,2]' }
+
+      it 'should find device of Apple iPhone 6' do
+        expect(device.device_type).to eq('smartphone')
+      end
+    end
+
+    context 'when models are NOT nested' do
+      let(:user_agent) { 'AIRNESS-AIR99/REV 2.2.1/Teleca Q03B1' }
+
+      it 'should find the device of Airness AIR99' do
+        expect(device.device_type).to eq('feature phone')
+      end
+    end
+
+
+  end
+
+end

--- a/spec/device_detector/device_spec.rb
+++ b/spec/device_detector/device_spec.rb
@@ -9,7 +9,7 @@ describe DeviceDetector::Device do
     context 'when models are nested' do
       let(:user_agent) { 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12B466 [FBDV/iPhone7,2]' }
 
-      it 'should find an Apple iPhone 6' do
+      it 'finds an Apple iPhone 6' do
         expect(device.name).to eq('iPhone 6')
       end
     end
@@ -17,31 +17,47 @@ describe DeviceDetector::Device do
     context 'when models are NOT nested' do
       let(:user_agent) { 'AIRNESS-AIR99/REV 2.2.1/Teleca Q03B1' }
 
-      it 'should find an Airness AIR99' do
+      it 'finds an Airness AIR99' do
         expect(device.name).to eq('AIR99')
+      end
+    end
+
+    context 'when it cannot find a device name' do
+      let(:user_agent) { 'UNKNOWN MODEL NAME' }
+
+      it 'returns nil' do
+        expect(device.name).to eq(nil)
       end
     end
 
   end
 
-  describe '#device_type' do
+  describe '#type' do
 
     context 'when models are nested' do
       let(:user_agent) { 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12B466 [FBDV/iPhone7,2]' }
 
-      it 'should find device of Apple iPhone 6' do
-        expect(device.device_type).to eq('smartphone')
+      it 'finds device of Apple iPhone 6' do
+        expect(device.type).to eq('smartphone')
       end
     end
 
     context 'when models are NOT nested' do
       let(:user_agent) { 'AIRNESS-AIR99/REV 2.2.1/Teleca Q03B1' }
 
-      it 'should find the device of Airness AIR99' do
-        expect(device.device_type).to eq('feature phone')
+      it 'finds the device of Airness AIR99' do
+        expect(device.type).to eq('feature phone')
       end
     end
 
+    context 'when it cannot find a device type' do
+      let(:user_agent) { 'UNKNOWN MODEL TYPE' }
+
+      it 'returns nil' do
+        expect(device.type).to eq(nil)
+      end
+
+    end
 
   end
 

--- a/spec/device_detector/model_extractor_spec.rb
+++ b/spec/device_detector/model_extractor_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe DeviceDetector::ModelExtractor do
+
+  subject(:extractor) { DeviceDetector::ModelExtractor.new(user_agent, regex_meta) }
+
+  describe '#call' do
+
+    context 'when matching against dynamic model' do
+
+      let(:regex_meta) do
+        {
+          'regex'  => '(?:Apple-)?iPhone ?(3GS?|4S?|5[CS]?|6(:? Plus)?)?',
+          'model'  => 'iPhone $1',
+          'device' => 'smartphone'
+        }
+      end
+
+      context 'when no dynamic match is found' do
+        let(:user_agent) { 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B466 Safari/600.1.4' }
+        let(:device_name) { 'iPhone' }
+
+        it 'should return the textual portion without trailing whitespace' do
+          expect(extractor.call).to eq(device_name)
+        end
+
+      end
+
+      context 'when a dynamic match is found' do
+        let(:user_agent) { 'Mozilla/5.0 (iPhone 5S; CPU iPhone OS 8_1_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B466 Safari/600.1.4' }
+        let(:device_name) { 'iPhone 5S' }
+
+        it 'should return the full device name' do
+          expect(extractor.call).to eq(device_name)
+        end
+
+      end
+
+    end
+
+    context 'when matching against static model' do
+
+      let(:user_agent) { 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12A365 Weibo (iPhone7,2)' }
+      let(:device_name) { 'iPhone 6' }
+      let(:regex_meta) do
+        {
+          'regex'  => '(?:Apple-)?iPhone7[C,]2',
+          'model'  => 'iPhone 6',
+          'device' => 'smartphone'
+        }
+      end
+
+      it 'should return the model name' do
+        expect(extractor.call).to eq(device_name)
+      end
+    
+    end
+
+  end
+
+end

--- a/spec/device_detector/model_extractor_spec.rb
+++ b/spec/device_detector/model_extractor_spec.rb
@@ -20,7 +20,7 @@ describe DeviceDetector::ModelExtractor do
         let(:user_agent) { 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B466 Safari/600.1.4' }
         let(:device_name) { 'iPhone' }
 
-        it 'should return the textual portion without trailing whitespace' do
+        it 'returns the textual portion without trailing whitespace' do
           expect(extractor.call).to eq(device_name)
         end
 
@@ -30,7 +30,7 @@ describe DeviceDetector::ModelExtractor do
         let(:user_agent) { 'Mozilla/5.0 (iPhone 5S; CPU iPhone OS 8_1_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B466 Safari/600.1.4' }
         let(:device_name) { 'iPhone 5S' }
 
-        it 'should return the full device name' do
+        it 'returns the full device name' do
           expect(extractor.call).to eq(device_name)
         end
 
@@ -50,7 +50,7 @@ describe DeviceDetector::ModelExtractor do
         }
       end
 
-      it 'should return the model name' do
+      it 'returns the model name' do
         expect(extractor.call).to eq(device_name)
       end
     

--- a/spec/device_detector/model_extractor_spec.rb
+++ b/spec/device_detector/model_extractor_spec.rb
@@ -53,7 +53,7 @@ describe DeviceDetector::ModelExtractor do
       it 'returns the model name' do
         expect(extractor.call).to eq(device_name)
       end
-    
+
     end
 
   end

--- a/spec/device_detector/version_extractor_spec.rb
+++ b/spec/device_detector/version_extractor_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe DeviceDetector::VersionExtractor do
         expect(extractor.call).to eq(version)
       end
 
-      it 'should remove trailing white spaces' do
-        regex_meta['version'] = regex_meta['version'] + '   ' # 3 trailing spaces
+      it 'removes trailing white spaces' do
+        regex_meta['version'] = regex_meta['version'] + '   '
         expect(extractor.call).to eq(version)
       end
 

--- a/spec/device_detector/version_extractor_spec.rb
+++ b/spec/device_detector/version_extractor_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe DeviceDetector::VersionExtractor do
     context 'regex with dynamic matching' do
 
       let(:user_agent) { 'Mozilla/5.0 (X11; U; Linux i686; nl; rv:1.8.1b2) Gecko/20060821 BonEcho/2.0b2 (Debian-1.99+2.0b2+dfsg-1)' }
+      let(:version) { 'BonEcho (2.0)' }
       let(:regex_meta) do
         {
           'regex' => '(BonEcho|GranParadiso|Lorentz|Minefield|Namoroka|Shiretoko)/(\d+[\.\d]+)',
@@ -36,7 +37,12 @@ RSpec.describe DeviceDetector::VersionExtractor do
       end
 
       it 'returns the correct version' do
-        expect(extractor.call).to eq('BonEcho (2.0)')
+        expect(extractor.call).to eq(version)
+      end
+
+      it 'should remove trailing white spaces' do
+        regex_meta['version'] = regex_meta['version'] + '   ' # 3 trailing spaces
+        expect(extractor.call).to eq(version)
       end
 
     end

--- a/spec/device_detector_spec.rb
+++ b/spec/device_detector_spec.rb
@@ -6,60 +6,86 @@ RSpec.describe DeviceDetector do
 
   context 'known user agent' do
 
-    let(:user_agent) { 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.69' }
+    context 'desktop chrome browser' do
 
-    describe '#name' do
+      let(:user_agent) { 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.69' }
 
-      it 'returns the name' do
-        expect(client.name).to eq('Chrome')
+      describe '#name' do
+
+        it 'returns the name' do
+          expect(client.name).to eq('Chrome')
+        end
+
+      end
+
+      describe '#full_version' do
+
+        it 'returns the full version' do
+          expect(client.full_version).to eq('30.0.1599.69')
+        end
+
+      end
+
+      describe '#os_name' do
+
+        it 'returns the operating system name' do
+          expect(client.os_name).to eq('Mac')
+        end
+
+      end
+
+      describe '#os_full_version' do
+
+        it 'returns the operating system full version' do
+          expect(client.os_full_version).to eq('10_8_5')
+        end
+
+      end
+
+      describe '#known?' do
+
+        it 'returns true' do
+          expect(client.known?).to eq(true)
+        end
+
+      end
+
+      describe '#bot?' do
+
+        it 'returns false' do
+          expect(client.bot?).to eq(false)
+        end
+
+      end
+
+      describe '#bot_name' do
+
+        it 'returns nil' do
+          expect(client.bot_name).to be_nil
+        end
+
       end
 
     end
 
-    describe '#full_version' do
+    context 'mobile iPhone 5S' do
 
-      it 'returns the full version' do
-        expect(client.full_version).to eq('30.0.1599.69')
+      let(:user_agent) { 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12B440 [FBDV/iPhone6,1]' }
+
+      describe '#device_name' do
+
+        it 'returns device name' do
+          expect(client.device_name).to eq('iPhone 5S')
+        end
+
       end
 
-    end
+      describe '#device_type' do
 
-    describe '#os_name' do
+        it 'returns the device type' do
+          expect(client.device_type).to eq('smartphone')
+        end
 
-      it 'returns the operating system name' do
-        expect(client.os_name).to eq('Mac')
-      end
-
-    end
-
-    describe '#os_full_version' do
-
-      it 'returns the operating system full version' do
-        expect(client.os_full_version).to eq('10_8_5')
-      end
-
-    end
-
-    describe '#known?' do
-
-      it 'returns true' do
-        expect(client.known?).to eq(true)
-      end
-
-    end
-
-    describe '#bot?' do
-
-      it 'returns false' do
-        expect(client.bot?).to eq(false)
-      end
-
-    end
-
-    describe '#bot_name' do
-
-      it 'returns nil' do
-        expect(client.bot_name).to be_nil
       end
 
     end


### PR DESCRIPTION
I updated the documentations to reflect this change (I also arbitrarily incremented the version to `0.4.0`, but you're free to control the versioning).

This uses the updated/fixed `mobiles.yml` (the fixes which I have a PR open for in the original repo [https://github.com/piwik/device-detector/pull/5313](here))

A test usage:
```ruby
ua = "Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12B466 WindVane tae_sdk_ios_1.3.0 Weibo (iPhone5,2__weibo__5.1.0__iphone__os8.1.3)"

device = DeviceDetector.new ua
# The two lines below are New :)!
device.device_name #=> 'iPhone 5'
device.device_type #=> 'smartphone'
# The lines below are the same as the old/standard behaviour
device.os_name #=> 'iOS'
device.os_full_version #=> '8_1_3'
```