### PR TITLE
Fix for Mac OS X full version

### DIFF
--- a/lib/device_detector/os.rb
+++ b/lib/device_detector/os.rb
@@ -1,6 +1,15 @@
 class DeviceDetector
   class OS < Parser
 
+    def full_version
+      raw_version = super
+
+      # This solution won't scale, but for now it will do
+      if raw_version && name == 'Mac'
+        raw_version.split('_').join('.')
+      end
+    end
+
     private
 
     def filenames

--- a/spec/device_detector/concrete_user_agent_spec.rb
+++ b/spec/device_detector/concrete_user_agent_spec.rb
@@ -42,5 +42,19 @@ describe DeviceDetector do
 
   end
 
+  describe 'Mac OS X' do
+
+    let(:user_agent) { 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.1 Safari/537.36' }
+
+    describe '#full_version' do
+
+      it 'returns the correct OS version' do
+        client.os_full_version.must_equal '10.10.1'
+      end
+
+    end
+
+  end
+
 end
 

--- a/spec/device_detector_spec.rb
+++ b/spec/device_detector_spec.rb
@@ -39,7 +39,7 @@ describe DeviceDetector do
       describe '#os_full_version' do
 
         it 'returns the operating system full version' do
-          client.os_full_version.must_equal '10_8_5'
+          client.os_full_version.must_equal '10.8.5'
         end
 
       end


### PR DESCRIPTION
As pointed out in #8, the full version of `Mac OS X` shall contain dots instead of underscores.

Fixes #8 