### PR TITLE
Give regexes their own cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ client.os_full_version # => '8'
 
 # For many devices, you can also query the device name (usually the model name)
 client.device_name # => 'iPhone 5'
-# Device types can be one of the following: desktop, smartphone, tablet, console, 
+# Device types can be one of the following: desktop, smartphone, tablet, console,
 # portable media player, tv, car browser, camera
 client.device_type # => 'smartphone'
 ```
@@ -71,6 +71,15 @@ end
 ```
 
 If you have a Rails application, you can create an initializer, for example `config/initializers/device_detector.rb`.
+
+If you have a long running process and you want to clear the cache, you can:
+
+```ruby
+# Remove user agent cache
+DeviceDetector.cache.force_purge!
+# Remove cached regexes
+DeviceDetector.regex_cache.force_purge!
+```
 
 ## Benchmarks
 

--- a/lib/device_detector.rb
+++ b/lib/device_detector.rb
@@ -142,6 +142,10 @@ class DeviceDetector
       yield(config)
     end
 
+    def regex_cache
+      @regex_cache ||= MemoryCache.new
+    end
+
   end
 
   private

--- a/lib/device_detector/memory_cache.rb
+++ b/lib/device_detector/memory_cache.rb
@@ -6,7 +6,7 @@ class DeviceDetector
     attr_reader :data, :max_keys, :lock
     private :lock
 
-    def initialize(config)
+    def initialize(config={})
       @data = {}
       @max_keys = config[:max_cache_keys] || DEFAULT_MAX_KEYS
       @lock = Mutex.new
@@ -36,6 +36,10 @@ class DeviceDetector
         value = yield if block_given?
         set(string_key, value)
       end
+    end
+
+    def force_purge!
+      @data.clear
     end
 
     private

--- a/lib/device_detector/parser.rb
+++ b/lib/device_detector/parser.rb
@@ -42,7 +42,7 @@ class DeviceDetector
     end
 
     def regexes_for(file_paths)
-      from_cache(['regexes', self.class]) do
+      from_regex_cache(self.class) do
         load_regexes(file_paths).flat_map { |path, regex| parse_regexes(path, regex) }
       end
     end
@@ -76,6 +76,10 @@ class DeviceDetector
 
     def from_cache(key)
       DeviceDetector.cache.get_or_set(key) { yield }
+    end
+
+    def from_regex_cache(key)
+      DeviceDetector.regex_cache.get_or_set(key) { yield }
     end
 
   end


### PR DESCRIPTION
This keeps regexes from being uncached after a large number of user agents are processed
Also add an option to forcibly purge the user agent (or regex) cache.  This is useful for long running processes that don't want to keep the cache around.