### PR TITLE
fix device type detection for firefox mobile on phone and tablet

### DIFF
--- a/lib/device_detector.rb
+++ b/lib/device_detector.rb
@@ -163,11 +163,11 @@ class DeviceDetector
   end
 
   def android_tablet_fragment?
-    user_agent =~ build_regex('Android; Tablet;')
+    user_agent =~ build_regex('Android(?: \d.\d(?:.\d)?)?; Tablet;')
   end
 
   def android_mobile_fragment?
-    user_agent =~ build_regex('Android; Mobile;')
+    user_agent =~ build_regex('Android(?: \d.\d(?:.\d)?)?; Mobile;')
   end
 
   def touch_enabled?

--- a/spec/device_detector_spec.rb
+++ b/spec/device_detector_spec.rb
@@ -70,6 +70,26 @@ describe DeviceDetector do
 
     end
 
+    describe 'firefox mobile phone' do
+
+      let(:user_agent) {'Mozilla/5.0 (Android 7.0; Mobile; rv:53.0) Gecko/53.0 Firefox/53.0'}
+
+      it 'detects smartphone' do
+        client.device_type.must_equal 'smartphone'
+      end
+
+    end
+
+    describe 'firefox mobile tablet' do
+
+      let(:user_agent) {'Mozilla/5.0 (Android 6.0.1; Tablet; rv:47.0) Gecko/47.0 Firefox/47.0'}
+
+      it 'detects tablet' do
+        client.device_type.must_equal 'tablet'
+      end
+
+    end
+
   end
 
   describe 'unknown user agent' do


### PR DESCRIPTION
With this change firefox mobile on smartphones and tablets will be recognized as device types smartphone and tablet (https://github.com/podigee/device_detector/issues/18).