### PR TITLE
Dont require semicolons for android mobile fragment

### DIFF
--- a/lib/device_detector.rb
+++ b/lib/device_detector.rb
@@ -163,11 +163,11 @@ class DeviceDetector
   end
 
   def android_tablet_fragment?
-    user_agent =~ build_regex('Android; Tablet;')
+    user_agent =~ build_regex('Android;? Tablet;?')
   end
 
   def android_mobile_fragment?
-    user_agent =~ build_regex('Android; Mobile;')
+    user_agent =~ build_regex('Android;? Mobile;?')
   end
 
   def touch_enabled?

--- a/spec/device_detector_spec.rb
+++ b/spec/device_detector_spec.rb
@@ -70,6 +70,14 @@ describe DeviceDetector do
 
     end
 
+    describe 'facebook mobile' do
+
+      let(:user_agent) { 'Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/35.0.0.48.273;]' }
+
+      it 'returns smartphone' do
+        client.device_type == 'smartphone'
+      end
+    end
   end
 
   describe 'unknown user agent' do


### PR DESCRIPTION
https://github.com/podigee/device_detector/issues/34

just making semicolons an optional character in android device strings.