### PR TITLE
Fix false detection of Android build OPR as Opera

### DIFF
--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -257,7 +257,7 @@
     default: 'Presto'
     versions:
       15: 'Blink'
-- regex: '(?:Opera|OPR)[/ ]?(?:9.80.*Version/)?(\d+[\.\d]+)'
+- regex: '(?:Opera[/ ]?|OPR[/ ])(?:9.80.*Version/)?(\d+[\.\d]+)'
   name: 'Opera'
   version: '$1'
   engine:

--- a/spec/fixtures/client/browser.yml
+++ b/spec/fixtures/client/browser.yml
@@ -261,6 +261,15 @@
     engine: WebKit
     engine_version: "534.30"
 -
+  user_agent: Mozilla/5.0 (Linux; Android 8.0.0; Pixel Build/OPR3.170623.008) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
+  client:
+    type: browser
+    name: Chrome Mobile
+    short_name: CM
+    version: "61.0.3163.98"
+    engine: Blink
+    engine_version: ""
+-
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.125 Safari/537.36
   client:
     type: browser


### PR DESCRIPTION
Android devices with build OPR are detected as Opera. Opera user agents using OPR requires a slash before the Opera version, the previous regular expression made this slash optional.