### PR TITLE
Add Android 9 support

### DIFF
--- a/regexes/oss.yml
+++ b/regexes/oss.yml
@@ -87,7 +87,7 @@
 ##########
 # Android
 ##########
-- regex: '(?:(?:Orca-)?Android|Adr)[ /](?:[a-z]+ )?(\d+[\.\d]+)'
+- regex: '(?:(?:Orca-)?Android|Adr)[ /](?:[a-z]+ )?(\d+[\.\d]*)'
   name: 'Android'
   version: '$1'
   

--- a/spec/fixtures/parser/oss.yml
+++ b/spec/fixtures/parser/oss.yml
@@ -337,6 +337,13 @@
     version: "10"
     platform:
 -
+  user_agent: Mozilla/5.0 (Linux; Android 9; Pixel 2 Build/PPR1.180610.009) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
+  os:
+    name: Android
+    short_name: AND
+    version: "9"
+    platform:
+-
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.0; de; rv:1.8.1.20) Gecko/20081217 Firefox/2.0.0.20
   os:
     name: Windows


### PR DESCRIPTION
Android 9 support was added by adjusting os version matching regexps so they allow a single digit version numbers. For more info see linked ticket.
Fixes #43