### PR TITLE
Add new Pingdom bot user agent

### DIFF
--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -924,7 +924,7 @@
     name: 'Picsearch'
     url: 'http://www.picsearch.com'
 
-- regex: 'Pingdom\.com'
+- regex: 'Pingdom(\.com)?(TMS)?'
   name: 'Pingdom Bot'
   category: 'Site Monitor'
   url: ''

--- a/spec/fixtures/detector/bots.yml
+++ b/spec/fixtures/detector/bots.yml
@@ -1801,7 +1801,16 @@
     producer:
       name: Pingdom AB
       url: https://www.pingdom.com
-- 
+-
+  user_agent: Mozilla/5.0 (Unknown; Linux x86_64) AppleWebKit/534.34 (KHTML, like Gecko) PingdomTMS/0.8.5 Safari/534.34
+  bot:
+    name: Pingdom Bot
+    category: Site Monitor
+    url: ""
+    producer:
+      name: Pingdom AB
+      url: https://www.pingdom.com
+-
   user_agent: Pinterest/0.2 (+http://www.pinterest.com/)
   bot:
     name: Pinterest


### PR DESCRIPTION
We observed the `Mozilla/5.0 (Unknown; Linux x86_64) AppleWebKit/534.34 (KHTML, like Gecko) PingdomTMS/0.8.5 Safari/534.34` user agent hitting our site. We think it's a new Pingdom bot. 

I updated the regex and added a test for the new user agent.

Let me know what you think, and if there's anything else I should add. Thanks for the helpful gem!