### PR TITLE
Fix concurrency issue with MemoryCache

### DIFF
--- a/lib/device_detector/memory_cache.rb
+++ b/lib/device_detector/memory_cache.rb
@@ -23,19 +23,15 @@ class DeviceDetector
       data[String(key)]
     end
 
-    def key?(string_key)
-      data.key?(string_key)
-    end
-
     def get_or_set(key, value = nil)
       string_key = String(key)
 
-      if key?(string_key)
-        get(string_key)
-      else
-        value = yield if block_given?
-        set(string_key, value)
-      end
+      result = get(string_key)
+
+      return result if result
+
+      value = yield if block_given?
+      set(string_key, value)
     end
 
     private


### PR DESCRIPTION
closes #54 

I also removed the `key?` method as it's not being used anywhere else and it can possibly lead to repeating the same concurrency pattern with checking and reading without a lock.