### PR TITLE
Use Ubuntu 18.04 on Travis (previous: 12.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: ruby
-sudo: false
-dist: precise
+dist: bionic
 rvm:
-  - 2.4.4
-  - 2.5.0
-  - 2.6.2
+  - 2.4
+  - 2.5
+  - 2.6
 before_install:
   - gem update --system
   - gem --version


### PR DESCRIPTION
Hey! Hope tests run fine on the latest Ubuntu. :) That's the warning Travis displays, but I went ahead and didn't use 16.04 but 18.04.

![Screenshot 2019-10-10 at 16 44 38](https://user-images.githubusercontent.com/1301152/66579625-65086880-eb7d-11e9-9329-0aa7ae768070.png)

I was wondering, according to the .gemspec file, the supported Ruby version by this gem is ≥1.9.3, is that information still correct, because if so, we should also test on these Ruby versions. And if note, update the .gemspec file.

https://github.com/podigee/device_detector/blob/6180c14a00dc6c44ebaec8d152a2b053ae7cfabb/device_detector.gemspec#L21

