### PR TITLE
Remove minitest deprecations

### DIFF
--- a/spec/device_detector/concrete_user_agent_spec.rb
+++ b/spec/device_detector/concrete_user_agent_spec.rb
@@ -13,7 +13,7 @@ describe DeviceDetector do
     describe '#device_name' do
 
       it 'returns device name' do
-        client.device_name.must_equal 'iPhone 5S'
+        value(client.device_name).must_equal 'iPhone 5S'
       end
 
     end
@@ -21,7 +21,7 @@ describe DeviceDetector do
     describe '#device_type' do
 
       it 'returns the device type' do
-        client.device_type.must_equal 'smartphone'
+        value(client.device_type).must_equal 'smartphone'
       end
 
     end
@@ -35,7 +35,7 @@ describe DeviceDetector do
     describe '#os_name' do
 
       it 'returns the OS name' do
-        client.os_name.must_equal 'Ubuntu'
+        value(client.os_name).must_equal 'Ubuntu'
       end
 
     end
@@ -49,7 +49,7 @@ describe DeviceDetector do
     describe '#full_version' do
 
       it 'returns the correct OS version' do
-        client.os_full_version.must_equal '10.10.1'
+        value(client.os_full_version).must_equal '10.10.1'
       end
 
     end
@@ -63,15 +63,15 @@ describe DeviceDetector do
       let(:user_agent) { 'Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.103 Safari/537.36' }
 
       it 'returns the correct client name' do
-        client.name.must_equal 'Chrome'
+        value(client.name).must_equal 'Chrome'
       end
 
       it 'recognizes the device name' do
-        client.device_name.must_be_nil
+        value(client.device_name).must_be_nil
       end
 
       it 'recognizes the device type' do
-        client.device_type.must_equal "desktop"
+        value(client.device_type).must_equal "desktop"
       end
 
     end
@@ -81,15 +81,15 @@ describe DeviceDetector do
       let(:user_agent) { 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36' }
 
       it 'returns the correct client name' do
-        client.name.must_equal 'Chrome'
+        value(client.name).must_equal 'Chrome'
       end
 
       it 'recognizes the device name' do
-        client.device_name.must_be_nil
+        value(client.device_name).must_be_nil
       end
 
       it 'recognizes the device type' do
-        client.device_type.must_equal "desktop"
+        value(client.device_type).must_equal "desktop"
       end
 
     end
@@ -101,15 +101,15 @@ describe DeviceDetector do
     let(:user_agent) { 'sprd-Galaxy-S5/1.0 Linux/2.6.35.7 Android/4.4.4 Release/11.29.2014 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile' }
 
     it 'returns the correct client name' do
-      client.name.must_equal "Android Browser"
+      value(client.name).must_equal "Android Browser"
     end
 
     it 'recognizes the device name' do
-      client.device_name.must_equal "GALAXY S5"
+      value(client.device_name).must_equal "GALAXY S5"
     end
 
     it 'recognizes the device type' do
-      client.device_type.must_equal "smartphone"
+      value(client.device_type).must_equal "smartphone"
     end
 
   end
@@ -119,18 +119,17 @@ describe DeviceDetector do
     let(:user_agent) { 'Lenovo-A398t+_TD/S100 Linux/3.4.5 Android/4.1.2 Release/09.10.2013 Browser/AppleWebKit534.30 Mobile Safari/534.30' }
 
     it 'returns the correct client name' do
-      client.name.must_equal "Android Browser"
+      value(client.name).must_equal "Android Browser"
     end
 
     it 'recognizes the device name' do
-      client.device_name.must_equal "A398t+"
+      value(client.device_name).must_equal "A398t+"
     end
 
     it 'recognizes the device type' do
-      client.device_type.must_equal "smartphone"
+      value(client.device_type).must_equal "smartphone"
     end
 
   end
 
 end
-

--- a/spec/device_detector/device_spec.rb
+++ b/spec/device_detector/device_spec.rb
@@ -12,7 +12,7 @@ describe DeviceDetector::Device do
       let(:user_agent) { 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12B466 [FBDV/iPhone7,2]' }
 
       it 'finds an Apple iPhone 6' do
-        device.name.must_equal 'iPhone 6'
+        value(device.name).must_equal 'iPhone 6'
       end
     end
 
@@ -20,7 +20,7 @@ describe DeviceDetector::Device do
       let(:user_agent) { 'AIRNESS-AIR99/REV 2.2.1/Teleca Q03B1' }
 
       it 'finds an Airness AIR99' do
-        device.name.must_equal 'AIR99'
+        value(device.name).must_equal 'AIR99'
       end
     end
 
@@ -28,7 +28,7 @@ describe DeviceDetector::Device do
       let(:user_agent) { 'UNKNOWN MODEL NAME' }
 
       it 'returns nil' do
-        device.name.must_be_nil
+        value(device.name).must_be_nil
       end
     end
 
@@ -40,7 +40,7 @@ describe DeviceDetector::Device do
       let(:user_agent) { 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12B466 [FBDV/iPhone7,2]' }
 
       it 'finds device of Apple iPhone 6' do
-        device.type.must_equal 'smartphone'
+        value(device.type).must_equal 'smartphone'
       end
     end
 
@@ -48,7 +48,7 @@ describe DeviceDetector::Device do
       let(:user_agent) { 'AIRNESS-AIR99/REV 2.2.1/Teleca Q03B1' }
 
       it 'finds the device of Airness AIR99' do
-        device.type.must_equal 'feature phone'
+        value(device.type).must_equal 'feature phone'
       end
     end
 
@@ -56,7 +56,7 @@ describe DeviceDetector::Device do
       let(:user_agent) { 'UNKNOWN MODEL TYPE' }
 
       it 'returns nil' do
-        device.type.must_be_nil
+        value(device.type).must_be_nil
       end
 
     end
@@ -66,7 +66,7 @@ describe DeviceDetector::Device do
       let(:user_agent) { 'Mozilla/5.0 (Linux; Android 4.4.2; es-us; SAMSUNG SM-G900F Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko)' }
 
       it 'falls back to top-level device' do
-        device.type.must_equal 'smartphone'
+        value(device.type).must_equal 'smartphone'
       end
 
     end
@@ -80,9 +80,9 @@ describe DeviceDetector::Device do
       let(:user_agent) { 'Mozilla/5.0 (Linux; Android 4.4.2; es-us; SAMSUNG SM-G900F Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko)' }
 
       it 'identifies the device' do
-        device.name.must_equal 'GALAXY S5'
-        device.type.must_equal 'smartphone'
-        device.brand.must_equal 'Samsung'
+        value(device.name).must_equal 'GALAXY S5'
+        value(device.type).must_equal 'smartphone'
+        value(device.brand).must_equal 'Samsung'
       end
 
     end
@@ -92,9 +92,9 @@ describe DeviceDetector::Device do
       let(:user_agent) { 'Mozilla/5.0 (Linux; U; Android 4.0; xx-xx; EK-GC100 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30' }
 
       it 'identifies the device' do
-        device.name.must_equal 'GALAXY Camera'
-        device.type.must_equal 'camera'
-        device.brand.must_equal 'Samsung'
+        value(device.name).must_equal 'GALAXY Camera'
+        value(device.type).must_equal 'camera'
+        value(device.brand).must_equal 'Samsung'
       end
 
     end
@@ -104,9 +104,9 @@ describe DeviceDetector::Device do
       let(:user_agent) { 'Mozilla/5.0 (X11; Linux) AppleWebKit/534.34 (KHTML, like Gecko) QtCarBrowser Safari/534.34' }
 
       it 'identifies the device' do
-        device.name.must_equal 'Model S'
-        device.type.must_equal 'car browser'
-        device.brand.must_be_nil
+        value(device.name).must_equal 'Model S'
+        value(device.type).must_equal 'car browser'
+        value(device.brand).must_be_nil
       end
 
     end
@@ -116,9 +116,9 @@ describe DeviceDetector::Device do
       let(:user_agent) { 'Opera/9.30 (Nintendo Wii; U; ; 2047-7;en)' }
 
       it 'identifies the device' do
-        device.name.must_equal 'Wii'
-        device.type.must_equal 'console'
-        device.brand.must_be_nil
+        value(device.name).must_equal 'Wii'
+        value(device.type).must_equal 'console'
+        value(device.brand).must_be_nil
       end
 
     end
@@ -128,9 +128,9 @@ describe DeviceDetector::Device do
       let(:user_agent) { 'Mozilla/5.0 (iPod touch; CPU iPhone OS 7_0_6 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11B651 Safari/9537.53' }
 
       it 'identifies the device' do
-        device.name.must_equal 'iPod Touch'
-        device.type.must_equal 'portable media player'
-        device.brand.must_equal 'Apple'
+        value(device.name).must_equal 'iPod Touch'
+        value(device.type).must_equal 'portable media player'
+        value(device.brand).must_equal 'Apple'
       end
 
     end
@@ -140,9 +140,9 @@ describe DeviceDetector::Device do
       let(:user_agent) { 'Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ HbbTV/1.1.1 ( ;LGE ;NetCast 4.0 ;03.10.81 ;1.0M ;)' }
 
       it 'identifies the device' do
-        device.name.must_equal 'NetCast 4.0'
-        device.type.must_equal 'tv'
-        device.brand.must_equal 'LG'
+        value(device.name).must_equal 'NetCast 4.0'
+        value(device.type).must_equal 'tv'
+        value(device.brand).must_equal 'LG'
       end
 
     end

--- a/spec/device_detector/memory_cache_spec.rb
+++ b/spec/device_detector/memory_cache_spec.rb
@@ -14,12 +14,12 @@ describe DeviceDetector::MemoryCache do
       it 'sets the value under the key' do
         subject.set(key, 'value')
 
-        subject.data[key].must_equal 'value'
+        value(subject.data[key]).must_equal 'value'
       end
 
       it 'returns the value' do
-        subject.set(key, 'value').must_equal 'value'
-        subject.set(key, false).must_equal false
+        value(subject.set(key, 'value')).must_equal 'value'
+        value(subject.set(key, false)).must_equal false
         assert_nil subject.set(key, nil)
       end
     end
@@ -30,7 +30,7 @@ describe DeviceDetector::MemoryCache do
       it 'sets the value under the key' do
         subject.set(key, 'value')
 
-        subject.data[String(key)].must_equal 'value'
+        value(subject.data[String(key)]).must_equal 'value'
       end
     end
 
@@ -41,14 +41,14 @@ describe DeviceDetector::MemoryCache do
       it 'sets the value under the key' do
         subject.set(key, nil)
 
-        subject.data[String(key)].must_equal internal_value
+        value(subject.data[String(key)]).must_equal internal_value
         assert_nil subject.get(key)
       end
 
       it 'sets the value under the key' do
         subject.get_or_set(key, nil)
 
-        subject.data[String(key)].must_equal internal_value
+        value(subject.data[String(key)]).must_equal internal_value
         assert_nil subject.get(key)
       end
     end
@@ -59,15 +59,15 @@ describe DeviceDetector::MemoryCache do
       it 'sets the value under the key' do
         subject.set(key, false)
 
-        subject.data[String(key)].must_equal false
-        subject.get(key).must_equal false
+        value(subject.data[String(key)]).must_equal false
+        value(subject.get(key)).must_equal false
       end
 
       it 'sets the value under the key' do
         subject.get_or_set(key, false)
 
-        subject.data[String(key)].must_equal false
-        subject.get(key).must_equal false
+        value(subject.data[String(key)]).must_equal false
+        value(subject.get(key)).must_equal false
       end
     end
   end
@@ -79,7 +79,7 @@ describe DeviceDetector::MemoryCache do
       it 'gets the value for the key' do
         subject.data[key] = 'value'
 
-        subject.get(key).must_equal 'value'
+        value(subject.get(key)).must_equal 'value'
       end
     end
 
@@ -89,7 +89,7 @@ describe DeviceDetector::MemoryCache do
       it 'gets the value for the key' do
         subject.data[String(key)] = 'value'
 
-        subject.get(key).must_equal 'value'
+        value(subject.get(key)).must_equal 'value'
       end
     end
   end
@@ -106,13 +106,13 @@ describe DeviceDetector::MemoryCache do
           block_called = true
         end
 
-        value.must_equal 'value'
-        block_called.must_equal false
+        value(value).must_equal 'value'
+        value(block_called).must_equal false
       end
 
       it 'returns the value' do
         subject.data[key] = 'value2'
-        subject.get_or_set(key, 'value').must_equal 'value2'
+        value(subject.get_or_set(key, 'value')).must_equal 'value2'
       end
     end
 
@@ -123,12 +123,12 @@ describe DeviceDetector::MemoryCache do
           block_called = true
         end
 
-        block_called.must_equal true
-        subject.data[key].must_equal true
+        value(block_called).must_equal true
+        value(subject.data[key]).must_equal true
       end
 
       it 'returns the value' do
-        subject.get_or_set(key, 'value').must_equal 'value'
+        value(subject.get_or_set(key, 'value')).must_equal 'value'
       end
     end
   end
@@ -142,7 +142,7 @@ describe DeviceDetector::MemoryCache do
       subject.set('3', 'baz')
       subject.set('4', 'boz')
 
-      subject.data.keys.size.must_equal 3
+      value(subject.data.keys.size).must_equal 3
     end
   end
 end

--- a/spec/device_detector/model_extractor_spec.rb
+++ b/spec/device_detector/model_extractor_spec.rb
@@ -23,7 +23,7 @@ describe DeviceDetector::ModelExtractor do
         let(:device_name) { 'iPhone' }
 
         it 'returns the textual portion without trailing whitespace' do
-          extractor.call.must_equal device_name
+          value(extractor.call).must_equal device_name
         end
 
       end
@@ -33,7 +33,7 @@ describe DeviceDetector::ModelExtractor do
         let(:device_name) { 'iPhone 5S' }
 
         it 'returns the full device name' do
-          extractor.call.must_equal device_name
+          value(extractor.call).must_equal device_name
         end
 
       end
@@ -53,7 +53,7 @@ describe DeviceDetector::ModelExtractor do
       end
 
       it 'returns the model name' do
-        extractor.call.must_equal device_name
+        value(extractor.call).must_equal device_name
       end
 
     end

--- a/spec/device_detector/version_extractor_spec.rb
+++ b/spec/device_detector/version_extractor_spec.rb
@@ -21,7 +21,7 @@ describe DeviceDetector::VersionExtractor do
       end
 
       it 'returns nil' do
-        extractor.call.must_equal ''
+        value(extractor.call).must_equal ''
       end
 
     end
@@ -39,12 +39,12 @@ describe DeviceDetector::VersionExtractor do
       end
 
       it 'returns the correct version' do
-        extractor.call.must_equal version
+        value(extractor.call).must_equal version
       end
 
       it 'removes trailing white spaces' do
         regex_meta[:version] = regex_meta[:version] + '   '
-        extractor.call.must_equal version
+        value(extractor.call).must_equal version
       end
 
     end
@@ -60,7 +60,7 @@ describe DeviceDetector::VersionExtractor do
       end
 
       it 'returns the correct version' do
-        extractor.call.must_equal '8.0'
+        value(extractor.call).must_equal '8.0'
       end
 
     end
@@ -71,10 +71,9 @@ describe DeviceDetector::VersionExtractor do
       let(:regex_meta) { {} }
 
       it 'returns nil' do
-        extractor.call.must_be_nil
+        value(extractor.call).must_be_nil
       end
 
     end
   end
 end
-

--- a/spec/device_detector_spec.rb
+++ b/spec/device_detector_spec.rb
@@ -13,49 +13,49 @@ describe DeviceDetector do
 
       describe '#name' do
         it 'returns the name' do
-          client.name.must_equal 'Chrome'
+          value(client.name).must_equal 'Chrome'
         end
       end
 
       describe '#full_version' do
         it 'returns the full version' do
-          client.full_version.must_equal '30.0.1599.69'
+          value(client.full_version).must_equal '30.0.1599.69'
         end
       end
 
       describe '#os_family' do
         it 'returns the operating system name' do
-          client.os_family.must_equal 'Mac'
+          value(client.os_family).must_equal 'Mac'
         end
       end
 
       describe '#os_name' do
         it 'returns the operating system name' do
-          client.os_name.must_equal 'Mac'
+          value(client.os_name).must_equal 'Mac'
         end
       end
 
       describe '#os_full_version' do
         it 'returns the operating system full version' do
-          client.os_full_version.must_equal '10.8.5'
+          value(client.os_full_version).must_equal '10.8.5'
         end
       end
 
       describe '#known?' do
         it 'returns true' do
-          client.known?.must_equal true
+          value(client.known?).must_equal true
         end
       end
 
       describe '#bot?' do
         it 'returns false' do
-          client.bot?.must_equal false
+          value(client.bot?).must_equal false
         end
       end
 
       describe '#bot_name' do
         it 'returns nil' do
-          client.bot_name.must_be_nil
+          value(client.bot_name).must_be_nil
         end
       end
     end
@@ -67,13 +67,13 @@ describe DeviceDetector do
 
       describe '#os_family' do
         it 'returns the operating system name' do
-          client.os_family.must_equal 'GNU/Linux'
+          value(client.os_family).must_equal 'GNU/Linux'
         end
       end
 
       describe '#os_name' do
         it 'returns the operating system name' do
-          client.os_name.must_equal 'Ubuntu'
+          value(client.os_name).must_equal 'Ubuntu'
         end
       end
     end
@@ -82,7 +82,7 @@ describe DeviceDetector do
       let(:user_agent) { 'Mozilla/5.0 (Android 7.0; Mobile; rv:53.0) Gecko/53.0 Firefox/53.0' }
 
       it 'detects smartphone' do
-        client.device_type.must_equal 'smartphone'
+        value(client.device_type).must_equal 'smartphone'
       end
     end
 
@@ -90,7 +90,7 @@ describe DeviceDetector do
       let(:user_agent) { 'Mozilla/5.0 (Android 6.0.1; Tablet; rv:47.0) Gecko/47.0 Firefox/47.0' }
 
       it 'detects tablet' do
-        client.device_type.must_equal 'tablet'
+        value(client.device_type).must_equal 'tablet'
       end
     end
   end
@@ -100,43 +100,43 @@ describe DeviceDetector do
 
     describe '#name' do
       it 'returns nil' do
-        client.name.must_be_nil
+        value(client.name).must_be_nil
       end
     end
 
     describe '#full_version' do
       it 'returns nil' do
-        client.full_version.must_be_nil
+        value(client.full_version).must_be_nil
       end
     end
 
     describe '#os_name' do
       it 'returns nil' do
-        client.os_name.must_be_nil
+        value(client.os_name).must_be_nil
       end
     end
 
     describe '#os_full_version' do
       it 'returns nil' do
-        client.os_full_version.must_be_nil
+        value(client.os_full_version).must_be_nil
       end
     end
 
     describe '#known?' do
       it 'returns false' do
-        client.known?.must_equal false
+        value(client.known?).must_equal false
       end
     end
 
     describe '#bot?' do
       it 'returns false' do
-        client.bot?.must_equal false
+        value(client.bot?).must_equal false
       end
     end
 
     describe '#bot_name' do
       it 'returns nil' do
-        client.bot_name.must_be_nil
+        value(client.bot_name).must_be_nil
       end
     end
   end
@@ -146,43 +146,43 @@ describe DeviceDetector do
 
     describe '#name' do
       it 'returns nil' do
-        client.name.must_be_nil
+        value(client.name).must_be_nil
       end
     end
 
     describe '#full_version' do
       it 'returns nil' do
-        client.full_version.must_be_nil
+        value(client.full_version).must_be_nil
       end
     end
 
     describe '#os_name' do
       it 'returns nil' do
-        client.os_name.must_be_nil
+        value(client.os_name).must_be_nil
       end
     end
 
     describe '#os_full_version' do
       it 'returns nil' do
-        client.os_full_version.must_be_nil
+        value(client.os_full_version).must_be_nil
       end
     end
 
     describe '#known?' do
       it 'returns false' do
-        client.known?.must_equal false
+        value(client.known?).must_equal false
       end
     end
 
     describe '#bot?' do
       it 'returns true' do
-        client.bot?.must_equal true
+        value(client.bot?).must_equal true
       end
     end
 
     describe '#bot_name' do
       it 'returns the name of the bot' do
-        client.bot_name.must_equal 'Googlebot'
+        value(client.bot_name).must_equal 'Googlebot'
       end
     end
   end


### PR DESCRIPTION
The global `.must_equal` and `.must_be_nil` will be removed in minitest 6. There's three options:
`_(obj).must_equal`
`value(obj).must_equal`
`expect(obj).must_equal`.

I chose `value(obj)` because it reads the most correct to me.
See also: https://stackoverflow.com/a/58128950