### PR TITLE
Update bots.yml to consider another string

### DIFF
--- a/spec/fixtures/detector/bots.yml
+++ b/spec/fixtures/detector/bots.yml
@@ -1095,6 +1095,15 @@
       name: Google Inc.
       url: http://www.google.com
 - 
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 Safari/537.36 (compatible; Google-Read-Aloud; +https://support.google.com/webmasters/answer/1061943)
+  bot:
+    name: Googlebot
+    category: Search bot
+    url: http://www.google.com/bot.html
+    producer:
+      name: Google Inc.
+      url: http://www.google.com
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.1; rv:6.0) Gecko/20110814 Firefox/6.0 Google (+https://developers.google.com/+/web/snippet/)
   bot:
     name: Googlebot


### PR DESCRIPTION
Adding another Google-Read-Aloud string I've detected
![Screen Shot 2019-10-15 at 8 30 52 AM](https://user-images.githubusercontent.com/238717/66827911-292b2580-ef26-11e9-91d1-8d86bfcae280.png)
 on one of my access.

