### PR TITLE
Support detection of any kind of googlebot

### DIFF
--- a/lib/device_detector/bot.rb
+++ b/lib/device_detector/bot.rb
@@ -11,5 +11,18 @@ class DeviceDetector
       ['bots.yml']
     end
 
+    def regexes_for(file_paths)
+      super + [google_regex]
+    end
+
+    def google_regex
+      {
+        name: 'Googlebot',
+        path: 'DeviceDetector::Bot',
+        regex: /.*support\.google\.com.*/
+      }.freeze
+    end
+
+
   end
 end

--- a/lib/device_detector/version.rb
+++ b/lib/device_detector/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class DeviceDetector
-  VERSION = '1.0.2'
+  VERSION = '1.0.2.1'
 end

--- a/spec/device_detector/bot_fixtures_spec.rb
+++ b/spec/device_detector/bot_fixtures_spec.rb
@@ -27,4 +27,16 @@ describe DeviceDetector::Bot do
       end
     end
   end
+
+  describe 'Googlebots' do
+    it 'detects any googlebot' do
+      user_agent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 '+
+        '(KHTML, like Gecko) Chrome/41.0.2272.118 Safari/537.36 '+
+        '(compatible; Google-Something-Something; '+
+        '+https://support.google.com/webmasters/answer/1061943)'
+      bot = DeviceDetector::Bot.new(user_agent)
+      assert bot.bot?, "isn't a bot"
+      assert_equal 'Googlebot', bot.name, "failed bot name detection"
+    end
+  end
 end


### PR DESCRIPTION
#63 seems like a very naive solution. Google may create new bots and agents as time goes by and since we're not looking for anything more specific than a `Googlebot` mark, this would make the code generic enough to contemplate any Google bot it'd be created in the future.