### PR TITLE
RegExp file caching

### DIFF
--- a/lib/device_detector/parser.rb
+++ b/lib/device_detector/parser.rb
@@ -1,7 +1,17 @@
-class DeviceDetector
-  class Parser < Struct.new(:user_agent)
+# frozen_string_literal: true
 
-    ROOT = File.expand_path('../../..', __FILE__)
+class DeviceDetector
+  class Parser
+    ROOT = File.expand_path('../..', __dir__)
+
+    REGEX_CACHE = ::DeviceDetector::MemoryCache.new({})
+    private_constant :REGEX_CACHE
+
+    def initialize(user_agent)
+      @user_agent = user_agent
+    end
+
+    attr_reader :user_agent
 
     def name
       from_cache(['name', self.class.name, user_agent]) do
@@ -42,7 +52,7 @@ class DeviceDetector
     end
 
     def regexes_for(file_paths)
-      from_cache(['regexes', self.class]) do
+      REGEX_CACHE.get_or_set(file_paths) do
         load_regexes(file_paths).flat_map { |path, regex| parse_regexes(path, regex) }
       end
     end

--- a/lib/device_detector/parser.rb
+++ b/lib/device_detector/parser.rb
@@ -42,12 +42,12 @@ class DeviceDetector
     end
 
     def filenames
-      fail NotImplementedError
+      raise NotImplementedError
     end
 
     def filepaths
       filenames.map do |filename|
-        [ filename.to_sym, File.join(ROOT, 'regexes', filename) ]
+        [filename.to_sym, File.join(ROOT, 'regexes', filename)]
       end
     end
 
@@ -64,16 +64,17 @@ class DeviceDetector
     def symbolize_keys!(object)
       case object
       when Array
-        object.map!{ |v| symbolize_keys!(v) }
+        object.map! { |v| symbolize_keys!(v) }
       when Hash
-        object.keys.each{ |k| object[k.to_sym] = symbolize_keys!(object.delete(k)) if k.is_a?(String) }
+        object.keys.each { |k| object[k.to_sym] = symbolize_keys!(object.delete(k)) if k.is_a?(String) }
       end
       object
     end
 
     def parse_regexes(path, raw_regexes)
       raw_regexes.map do |meta|
-        fail "invalid device spec: #{meta.inspect}" unless meta[:regex].is_a? String
+        raise "invalid device spec: #{meta.inspect}" unless meta[:regex].is_a? String
+
         meta[:regex] = build_regex(meta[:regex])
         meta[:path] = path
         meta
@@ -87,6 +88,5 @@ class DeviceDetector
     def from_cache(key)
       DeviceDetector.cache.get_or_set(key) { yield }
     end
-
   end
 end


### PR DESCRIPTION
> While using the DeviceDetector gem I've noticed, that the same cache is being used to store the final detection results as well as to tackle the internal caching.
> 
> This approach causes a YAML reload of regexps when enough browsers are being recognized.

fixes https://github.com/podigee/device_detector/issues/69