### PR TITLE
Update list of possible device types in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ client.os_name # => 'Windows'
 client.os_full_version # => '8'
 
 # Device types can be one of the following: desktop, smartphone, tablet, feature phone,
-# console, tv, car browser, camera, portable media player, phablet, smart speaker, or
+# console, tv, car browser, smart display, camera, portable media player, phablet, smart speaker, or
 # wearable.
 client.device_type # => 'smartphone'
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,13 @@ client.full_version # => '30.0.1599.69'
 client.os_name # => 'Windows'
 client.os_full_version # => '8'
 
+# Device types can be one of the following: desktop, smartphone, tablet, feature phone,
+# console, tv, car browser, camera, portable media player, phablet, smart speaker, or
+# wearable.
+client.device_type # => 'smartphone'
+
 # For many devices, you can also query the device name (usually the model name)
 client.device_name # => 'iPhone 5'
-# Device types can be one of the following: desktop, smartphone, tablet, console,
-# portable media player, tv, car browser, camera
-client.device_type # => 'smartphone'
 ```
 
 `DeviceDetector` will return `nil` on all attributes, if the `user_agent` is unknown.


### PR DESCRIPTION
Adds various device types such as `phablet` and `wearable`.

List taken from here: https://github.com/podigee/device_detector/blob/5417cf0a0334558004aa21e0396e7fed3b90db64/lib/device_detector/device.rb#L6-L20