### PR TITLE
Unquote Sec-CH-UA-Platform and Sec-CH-UA-Platform-Version

### DIFF
--- a/lib/device_detector/client_hint.rb
+++ b/lib/device_detector/client_hint.rb
@@ -14,10 +14,10 @@ class DeviceDetector
       return if headers.nil?
 
       @headers = headers
-      @full_version = headers['Sec-CH-UA-Full-Version']
+      @full_version = unquote(headers['Sec-CH-UA-Full-Version'])
       @browser_list = extract_browser_list
       @app_name = extract_app_name
-      @platform = headers['Sec-CH-UA-Platform']
+      @platform = unquote(headers['Sec-CH-UA-Platform'])
       @platform_version = extract_platform_version
       @mobile = headers['Sec-CH-UA-Mobile']
       @model = extract_model
@@ -63,7 +63,7 @@ class DeviceDetector
       return if  headers['Sec-CH-UA-Platform-Version'].nil?
       return if  headers['Sec-CH-UA-Platform-Version'] == ''
 
-      headers['Sec-CH-UA-Platform-Version']
+      unquote(headers['Sec-CH-UA-Platform-Version'])
     end
 
     # https://github.com/matomo-org/device-detector/blob/28211c6f411528abf41304e07b886fdf322a49b7/Parser/OperatingSystem.php#L330
@@ -152,9 +152,9 @@ class DeviceDetector
     end
 
     def extract_browser_name_and_version(component)
-      component_and_version = component.gsub('"', '').split("\;v=")
+      component_and_version = unquote(component).split("\;v=")
       name = name_from_known_browsers(component_and_version.first)
-      browser_version = full_version&.gsub('"', '') || component_and_version.last
+      browser_version = full_version || component_and_version.last
       { name: name, version: browser_version }
     end
 
@@ -176,6 +176,10 @@ class DeviceDetector
       return if headers['Sec-CH-UA-Model'].nil? || headers['Sec-CH-UA-Model'] == ''
 
       headers['Sec-CH-UA-Model']
+    end
+
+    def unquote(str)
+      str&.gsub('"', '')
     end
   end
 end

--- a/spec/fixtures/client/browser.yml
+++ b/spec/fixtures/client/browser.yml
@@ -4465,10 +4465,10 @@
     family: Chrome
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="98.0.4758.109", "Gener8";v="98.0.4758.109"'
-    Sec-CH-UA-Platform: "Windows"
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "98.0.4758.109"
-    Sec-CH-UA-Platform-Version: "10.0.0"
+    Sec-CH-UA-Full-Version: '"98.0.4758.109"'
+    Sec-CH-UA-Platform-Version: '"10.0.0"'
     Sec-CH-UA-Arch: "x86"
     Sec-CH-UA-Bitness: "64"
     Sec-CH-Prefers-Color-Scheme: "light"
@@ -4483,10 +4483,10 @@
     family: Opera
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="99.0.4844.16", "Opera Crypto";v="99.0.4844.16"'
-    Sec-CH-UA-Platform: "Windows"
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "99.0.4844.16"
-    Sec-CH-UA-Platform-Version: "10.0.0"
+    Sec-CH-UA-Full-Version: '"99.0.4844.16"'
+    Sec-CH-UA-Platform-Version: '"10.0.0"'
     Sec-CH-UA-Arch: "x86"
     Sec-CH-UA-Bitness: "64"
     Sec-CH-Prefers-Color-Scheme: "dark"
@@ -4501,10 +4501,10 @@
     family: Chrome
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="98", "Whale";v="3.13.131.36"'
-    Sec-CH-UA-Platform: "Windows"
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "3.13.131.36"
-    Sec-CH-UA-Platform-Version: "14.0.0"
+    Sec-CH-UA-Full-Version: '"3.13.131.36"'
+    Sec-CH-UA-Platform-Version: '"14.0.0"'
     Sec-CH-UA-Arch: "x86"
     Sec-CH-UA-Bitness: "64"
     Sec-CH-Prefers-Color-Scheme: "light"
@@ -4519,10 +4519,10 @@
     family: Opera
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="98.0.4758.102", "Opera GX";v="98.0.4758.102"'
-    Sec-CH-UA-Platform: "Windows"
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "98.0.4758.102"
-    Sec-CH-UA-Platform-Version: "14.0.0"
+    Sec-CH-UA-Full-Version: '"98.0.4758.102"'
+    Sec-CH-UA-Platform-Version: '"14.0.0"'
     Sec-CH-UA-Arch: "x86"
     Sec-CH-UA-Bitness: "64"
     Sec-CH-Prefers-Color-Scheme: "dark"
@@ -6040,7 +6040,7 @@
     family: Chrome
   headers:
     Sec-CH-UA: '"(Not(A:Brand";v="8.0.0.0", "WaveBrowser";v="1.1.6.4", "WaveBrowser";v="1.1.6.4"'
-    Sec-CH-UA-Platform: 'Windows'
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: '?0'
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.74 Safari/537.36
@@ -6053,7 +6053,7 @@
     family: Chrome
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="99.0.15185.77", "CCleaner Browser";v="99.0.15185.77"'
-    Sec-CH-UA-Platform: 'Windows'
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: '?0'
 -
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.132 Safari/537.36
@@ -6066,7 +6066,7 @@
     family: Chrome
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99", "Chromium";v="98", "Sidekick";v="98"'
-    Sec-CH-UA-Platform: 'macOS'
+    Sec-CH-UA-Platform: '"macOS"'
     Sec-CH-UA-Mobile: '?0'
 -
   user_agent: 'Opera%20GX/416.0.0 CFNetwork/1331.0.7 Darwin/21.4.0'
@@ -6472,7 +6472,7 @@
     family: Chrome
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="2022.04"'
-    Sec-CH-UA-Platform: 'Linux'
+    Sec-CH-UA-Platform: '"Linux"'
     Sec-CH-UA-Mobile: '?0'
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.148 Atom/23.0.0.28 Safari/537.36
@@ -6485,7 +6485,7 @@
     family: Chrome
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99", "Chromium";v="102", "Atom";v="23"'
-    Sec-CH-UA-Platform: "Windows"
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: "?0"
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.148 Atom/23.0.0.28 Safari/537.36
@@ -6498,10 +6498,10 @@
     family: Chrome
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="102.0.5005.148", "Atom";v="23.0.0.28"'
-    Sec-CH-UA-Platform: "Windows"
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "102.0.5005.148"
-    Sec-CH-UA-Platform-Version: "10.0.0"
+    Sec-CH-UA-Full-Version: '"102.0.5005.148"'
+    Sec-CH-UA-Platform-Version: '"10.0.0"'
     Sec-CH-UA-Arch: "x86"
     Sec-CH-UA-Bitness: "64"
     Sec-CH-Prefers-Color-Scheme: "light"
@@ -6516,7 +6516,7 @@
     family: Chrome
   headers:
     Sec-CH-UA: '"Chromium";v="103", ".Not/A)Brand";v="99"'
-    Sec-CH-UA-Platform: "Windows"
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: "?0"
 -
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.88 Safari/537.36 OPR/85.0.4341.13
@@ -6529,10 +6529,10 @@
     family: Opera
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="99.0.4844.88"'
-    Sec-CH-UA-Platform: "Android"
+    Sec-CH-UA-Platform: '"Android"'
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "99.0.4844.88"
-    Sec-CH-UA-Platform-Version: "9.0.0"
+    Sec-CH-UA-Full-Version: '"99.0.4844.88"'
+    Sec-CH-UA-Platform-Version: '"9.0.0"'
     Sec-CH-UA-Model: "STF-L09"
     Sec-CH-Prefers-Color-Scheme: "light"
 -
@@ -7127,7 +7127,7 @@
     family: Chrome
   headers:
     Sec-CH-UA: '"(Not(A:Brand";v="8", "Chromium";v="2022"'
-    Sec-CH-UA-Platform: 'Windows'
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: '?0'
 -
   user_agent: Mozilla/5.0 (Linux; Android 10; VOG-L29; HMSCore 6.6.0.352; GMSCore 22.26.15) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.105 HuaweiBrowser/12.1.3.301 Mobile Safari/537.36
@@ -7152,7 +7152,7 @@
     family: Chrome
   headers:
     Sec-CH-UA: '"Chromium";v="106", "Brave";v="106", "Not;A=Brand";v="99"'
-    Sec-CH-UA-Platform: "Android"
+    Sec-CH-UA-Platform: '"Android"'
     Sec-CH-UA-Mobile: "?1"
 -
   user_agent: Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Mobile Safari/537.36
@@ -7165,7 +7165,7 @@
     family: Chrome
   headers:
     Sec-CH-UA: '"Chromium";v="106", "Brave Browser";v="106", "Not;A=Brand";v="99"'
-    Sec-CH-UA-Platform: "Android"
+    Sec-CH-UA-Platform: '"Android"'
     Sec-CH-UA-Mobile: "?1"
 -
   user_agent: Mozilla/5.0 (X11; Linux x86_64; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/24.3.0.4.63.416895357 SamsungBrowser/4.0 Chrome/106.0.5249.168 VR Safari/537.36
@@ -7178,7 +7178,7 @@
     family: Chrome
   headers:
     Sec-CH-UA: '"Chromium";v="106", "Oculus Browser";v="24", "Not;A=Brand";v="99"'
-    Sec-CH-UA-Platform: "Linux"
+    Sec-CH-UA-Platform: '"Linux"'
     Sec-CH-UA-Mobile: "?0"
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36
@@ -7191,7 +7191,7 @@
     family: Chrome
   headers:
     Sec-CH-UA: '"Chromium";v="2021", ";Not A Brand";v="99"'
-    Sec-CH-UA-Platform: "Windows"
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: "?0"
     Sec-CH-UA-Full-Version: '"2021.12"'
 -
@@ -7250,7 +7250,7 @@
     family: Chrome
   headers:
     Sec-CH-UA: '"Wavebox";v="111", "Not(A:Brand";v="8", "Chromium";v="111"'
-    Sec-CH-UA-Platform: 'macOS'
+    Sec-CH-UA-Platform: '"macOS"'
     Sec-CH-UA-Mobile: '?0'
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36 Edg/86.0.622.69
@@ -7263,7 +7263,7 @@
     family: Internet Explorer
   headers:
     Sec-CH-UA: 'Microsoft Edge;v="86", "Chromium";v="86", ";Not A Brand";v="99"'
-    Sec-CH-UA-Platform: 'Windows'
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: '?0'
 -
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-P600) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36
@@ -7342,7 +7342,7 @@
     family: Chrome
   headers:
     Sec-CH-UA: '"HeadlessChrome";v="113", "Chromium";v="113", "Not-A.Brand";v="24"'
-    Sec-CH-UA-Platform: 'Linux'
+    Sec-CH-UA-Platform: '"Linux"'
     Sec-CH-UA-Mobile: '?0'
 -
   user_agent: ddg_android/5.114.3 (com.duckduckgo.mobile.android; Android API 22)
@@ -7547,7 +7547,7 @@
     family: Chrome
   headers:
     Sec-CH-UA: '"Chromium";v="116.0.22144.111", "Not)A;Brand";v="24.0.0.0", "Avira Secure Browser";v="116.0.22144.111"'
-    Sec-CH-UA-Full-Version: "116.0.22144.111"
+    Sec-CH-UA-Full-Version: '"116.0.22144.111"'
 -
   user_agent: Mozilla/5.0 (Linux; Android 13; SAMSUNG SM-A146U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/23.0 Chrome/115.0.0.0 Mobile Safari/537.36
   client:

--- a/spec/fixtures/detector/clienthints.yml
+++ b/spec/fixtures/detector/clienthints.yml
@@ -3,9 +3,9 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ZC554KL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.87 Mobile Safari/537.36
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99", "Chromium";v="98", "Google Chrome";v="98"'
-    Sec-CH-UA-Platform: "Android"
+    Sec-CH-UA-Platform: '"Android"'
     Sec-CH-UA-Mobile: "?1"
-    Sec-CH-UA-Full-Version: "98.0.4758.87"
+    Sec-CH-UA-Full-Version: '"98.0.4758.87"'
     Sec-CH-UA-Platform-Version: "8.1.0"
     Sec-CH-UA-Model: "ZC554KL"
     Sec-CH-Prefers-Color-Scheme: "light"
@@ -29,9 +29,9 @@
   user_agent: Mozilla/5.0 (Linux; arm_64; Android 8.1.0; ZC554KL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.174 YaApp_Android/22.14.1 YaSearchBrowser/22.14.1 BroPP/1.0 SA/3 Mobile Safari/537.36
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99", "Chromium";v="96", "Yandex";v="22"'
-    Sec-CH-UA-Platform: "Android"
+    Sec-CH-UA-Platform: '"Android"'
     Sec-CH-UA-Mobile: "?1"
-    Sec-CH-UA-Full-Version: "22.1.4.706"
+    Sec-CH-UA-Full-Version: '"22.1.4.706"'
     Sec-CH-UA-Platform-Version: "8.1.0"
     Sec-CH-UA-Model: "ZC554KL"
     Sec-CH-Prefers-Color-Scheme: "light"
@@ -55,9 +55,9 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ZC554KL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.104 Mobile Safari/537.36 OPR/67.1.3508.63168
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99", "Chromium";v="96", "Opera";v="82", "OperaMobile";v="67"'
-    Sec-CH-UA-Platform: "Android"
+    Sec-CH-UA-Platform: '"Android"'
     Sec-CH-UA-Mobile: "?1"
-    Sec-CH-UA-Full-Version: "96.0.4664.104"
+    Sec-CH-UA-Full-Version: '"96.0.4664.104"'
     Sec-CH-UA-Platform-Version: "8.1.0"
     Sec-CH-UA-Model: "ZC554KL"
     Sec-CH-Prefers-Color-Scheme: "light"
@@ -82,8 +82,8 @@
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99", "Chromium";v="97", "Google Chrome";v="97"'
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Platform: "Windows"
-    Sec-CH-UA-Platform-Version: "14.0.0"
+    Sec-CH-UA-Platform: '"Windows"'
+    Sec-CH-UA-Platform-Version: '"14.0.0"'
   os:
     name: Windows
     version: "11"
@@ -105,7 +105,7 @@
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99", "Chromium";v="97", "Google Chrome";v="97"'
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Platform: "Windows"
+    Sec-CH-UA-Platform: '"Windows"'
   os:
     name: Windows
     version: "10"
@@ -127,8 +127,8 @@
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99", "Chromium";v="95", "Microsoft Edge";v="95"'
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Platform: "Windows"
-    Sec-CH-UA-Platform-Version: "14.0.0"
+    Sec-CH-UA-Platform: '"Windows"'
+    Sec-CH-UA-Platform-Version: '"14.0.0"'
   os:
     name: Windows
     version: "11"
@@ -151,7 +151,7 @@
     Sec-CH-UA: "\" Not A;Brand\";v=\"99\", \"Chromium\";v=\"98\", \"Opera\";v=\"84\""
     Sec-CH-UA-Mobile: "?0"
     Sec-CH-UA-Full-Version-List: "\" Not A;Brand\";v=\"99.0.0.0\", \"Chromium\";v=\"98.0.4758.82\", \"Opera\";v=\"98.0.4758.82\""
-    Sec-CH-UA-Platform: "Windows"
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Platform-Version: "10.0.0"
   os:
     name: Windows
@@ -174,8 +174,8 @@
   headers:
     Sec-CH-UA: "\" Not A;Brand\";v=\"99\", \"Chromium\";v=\"98\", \"Google Chrome\";v=\"98\""
     Sec-CH-UA-Mobile: "?1"
-    Sec-CH-UA-Full-Version: "98.0.4758.101"
-    Sec-CH-UA-Platform: "Android"
+    Sec-CH-UA-Full-Version: '"98.0.4758.101"'
+    Sec-CH-UA-Platform: '"Android"'
     Sec-CH-UA-Platform-Version: "11.0.0"
     Sec-CH-UA-Model: "DN2103"
   os:
@@ -198,9 +198,9 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="98.0.14335.105", "CCleaner Browser";v="98.0.14335.105"'
-    Sec-CH-UA-Platform: "Windows"
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "98.0.14335.105"
+    Sec-CH-UA-Full-Version: '"98.0.14335.105"'
     Sec-CH-UA-Platform-Version: "10.0.0"
     Sec-CH-UA-Model: ""
     Sec-CH-Prefers-Color-Scheme: "light"
@@ -224,9 +224,9 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="98.0.14335.104", "AVG Secure Browser";v="98.0.14335.104"'
-    Sec-CH-UA-Platform: "Windows"
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "98.0.14335.104"
+    Sec-CH-UA-Full-Version: '"98.0.14335.104"'
     Sec-CH-UA-Platform-Version: "10.0.0"
     Sec-CH-UA-Model: ""
     Sec-CH-Prefers-Color-Scheme: "light"
@@ -250,9 +250,9 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="98.0.14335.103", "Avast Secure Browser";v="98.0.14335.103"'
-    Sec-CH-UA-Platform: "Windows"
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "98.0.14335.103"
+    Sec-CH-UA-Full-Version: '"98.0.14335.103"'
     Sec-CH-UA-Platform-Version: "10.0.0"
     Sec-CH-UA-Model: ""
     Sec-CH-Prefers-Color-Scheme: "light"
@@ -276,10 +276,10 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; KFKAWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.1.148 like Chrome/98.0.4758.101 Safari/537.36
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="98.0.4758.101"'
-    Sec-CH-UA-Platform: "Android"
+    Sec-CH-UA-Platform: '"Android"'
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "98.0.4758.101"
-    Sec-CH-UA-Platform-Version: "9.0.0"
+    Sec-CH-UA-Full-Version: '"98.0.4758.101"'
+    Sec-CH-UA-Platform-Version: '"9.0.0"'
     Sec-CH-UA-Model: "KFKAWI"
     Sec-CH-Prefers-Color-Scheme: "light"
   os:
@@ -302,9 +302,9 @@
   user_agent: Mozilla/5.0 (Linux; Android 11; sohKwhigbQ; U; en) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.101 Mobile AvastSecureBrowser/6.6.0 Build/3850 Safari/537.36
   headers:
     Sec-CH-UA: '"AvastSecureBrowser";v="6.6.0", " Not A;Brand";v="99.0.0.0", "Chromium";v="98.0.4758.101"'
-    Sec-CH-UA-Platform: "Android"
+    Sec-CH-UA-Platform: '"Android"'
     Sec-CH-UA-Mobile: "?1"
-    Sec-CH-UA-Full-Version: "6.6.0"
+    Sec-CH-UA-Full-Version: '"6.6.0"'
     Sec-CH-UA-Platform-Version: "11"
     Sec-CH-UA-Arch: "[arm64-v8a, armeabi-v7a, armeabi]"
     Sec-CH-Prefers-Color-Scheme: "light"
@@ -328,9 +328,9 @@
   user_agent: ""
   headers:
     Sec-CH-UA: '"AvastSecureBrowser";v="6.6.0", " Not A;Brand";v="99.0.0.0", "Chromium";v="98.0.4758.101"'
-    Sec-CH-UA-Platform: "Android"
+    Sec-CH-UA-Platform: '"Android"'
     Sec-CH-UA-Mobile: "?1"
-    Sec-CH-UA-Full-Version: "6.6.0"
+    Sec-CH-UA-Full-Version: '"6.6.0"'
     Sec-CH-UA-Platform-Version: "11"
     Sec-CH-UA-Arch: "[arm64-v8a, armeabi-v7a, armeabi]"
     Sec-CH-Prefers-Color-Scheme: "light"
@@ -354,9 +354,9 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36 Edg/98.0.1108.56
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="98.0.1108.56", "Microsoft Edge";v="98.0.1108.56"'
-    Sec-CH-UA-Platform: "Windows"
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "98.0.1108.56"
+    Sec-CH-UA-Full-Version: '"98.0.1108.56"'
     Sec-CH-UA-Platform-Version: "10.0.0"
     Sec-CH-UA-Arch: "x86"
     Sec-CH-UA-Bitness: "32"
@@ -383,7 +383,7 @@
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="98.0.4758.109", "Google Chrome";v="98.0.4758.109"'
     Sec-CH-UA-Platform: "macOS"
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "98.0.4758.109"
+    Sec-CH-UA-Full-Version: '"98.0.4758.109"'
     Sec-CH-UA-Platform-Version: "10.14.6"
     Sec-CH-UA-Arch: "x86"
     Sec-CH-UA-Bitness: "64"
@@ -410,7 +410,7 @@
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="98.0.4758.102", "Opera";v="98.0.4758.102"'
     Sec-CH-UA-Platform: "macOS"
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "98.0.4758.102"
+    Sec-CH-UA-Full-Version: '"98.0.4758.102"'
     Sec-CH-UA-Platform-Version: "11.6.0"
     Sec-CH-UA-Arch: "arm"
     Sec-CH-UA-Bitness: "64"
@@ -437,7 +437,7 @@
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="98.0.4758.102"'
     Sec-CH-UA-Platform: "Linux"
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "98.0.4758.102"
+    Sec-CH-UA-Full-Version: '"98.0.4758.102"'
     Sec-CH-UA-Platform-Version: "5.4.0"
     Sec-CH-UA-Arch: "x86"
     Sec-CH-UA-Bitness: "64"
@@ -462,9 +462,9 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; X30) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.101 Mobile Safari/537.36
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="98.0.4758.101", "Google Chrome";v="98.0.4758.101"'
-    Sec-CH-UA-Platform: "Android"
+    Sec-CH-UA-Platform: '"Android"'
     Sec-CH-UA-Mobile: "?1"
-    Sec-CH-UA-Full-Version: "98.0.4758.101"
+    Sec-CH-UA-Full-Version: '"98.0.4758.101"'
     Sec-CH-UA-Platform-Version: "10.0.0"
     Sec-CH-UA-Model: "X30"
     Sec-CH-Prefers-Color-Scheme: "light"
@@ -487,10 +487,10 @@
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36 Edg/97.0.1072.66
   headers:
-    Sec-CH-UA-Platform: "Windows"
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "97.0.1072.66"
-    Sec-CH-UA-Platform-Version: "14.0.0"
+    Sec-CH-UA-Full-Version: '"97.0.1072.66"'
+    Sec-CH-UA-Platform-Version: '"14.0.0"'
     Sec-CH-UA-Arch: "x86"
     Sec-CH-UA-Bitness: "64"
     Sec-CH-UA-Model: "Xbox"
@@ -515,9 +515,9 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.16 Safari/537.36 OPR/85.0.4338.0 (Edition developer)
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="99.0.4844.16", "Opera Crypto";v="99.0.4844.16"'
-    Sec-CH-UA-Platform: "Windows"
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "99.0.4844.16"
+    Sec-CH-UA-Full-Version: '"99.0.4844.16"'
     Sec-CH-UA-Platform-Version: "10.0.0"
     Sec-CH-UA-Arch: "x86"
     Sec-CH-UA-Bitness: "64"
@@ -542,9 +542,9 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.109 Safari/537.36
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="98.0.4758.109", "Gener8";v="98.0.4758.109"'
-    Sec-CH-UA-Platform: "Windows"
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "98.0.4758.109"
+    Sec-CH-UA-Full-Version: '"98.0.4758.109"'
     Sec-CH-UA-Platform-Version: "10.0.0"
     Sec-CH-UA-Arch: "x86"
     Sec-CH-UA-Bitness: "64"
@@ -580,7 +580,7 @@
     Sec-CH-UA: '" Not A;Brand";v="99", "Chromium";v="98.0.4758.102", "Google Chrome";v="98.0.4758.102"'
     Sec-CH-UA-Platform: "Unknown"
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "98.0.4758.102"
+    Sec-CH-UA-Full-Version: '"98.0.4758.102"'
     Sec-CH-UA-Platform-Version: "0"
     Sec-CH-UA-Arch: "x86"
     Sec-CH-UA-Model: "Model"
@@ -615,7 +615,7 @@
   headers:
     Sec-CH-UA-Platform: "Chromium OS"
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "94.0.4606.126"
+    Sec-CH-UA-Full-Version: '"94.0.4606.126"'
     Sec-CH-UA-Platform-Version: "14150.90.0"
     Sec-CH-UA-Arch: "x86"
     Sec-CH-UA-Bitness: "64"
@@ -641,7 +641,7 @@
   headers:
     Sec-CH-UA-Platform: "Linux"
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "92.0.4515.98"
+    Sec-CH-UA-Full-Version: '"92.0.4515.98"'
     Sec-CH-UA-Platform-Version: "13597.84.0"
     Sec-CH-UA-Arch: "arm"
   os:
@@ -663,7 +663,7 @@
 -
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.6167.5881 Safari/537.36
   headers:
-    Sec-CH-UA-Platform: "Windows"
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: "?0"
     Sec-CH-UA-Full-Version: "?1"
   os:
@@ -688,7 +688,7 @@
     Sec-CH-UA: '"Chromium";v="98.0.4758.121", " Not A;Brand";v="99.0.0.0"'
     Sec-CH-UA-Platform: "Linux"
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "98.0.4758.121"
+    Sec-CH-UA-Full-Version: '"98.0.4758.121"'
     Sec-CH-UA-Platform-Version: "5.16.11"
     Sec-CH-UA-Arch: "x86"
     Sec-CH-UA-Bitness: "64"
@@ -753,7 +753,7 @@
   user_agent: Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Mobile Safari/537.36
   headers:
     Sec-CH-UA: '"Chromium";v="106", "Brave";v="106", "Not;A=Brand";v="99"'
-    Sec-CH-UA-Platform: "Android"
+    Sec-CH-UA-Platform: '"Android"'
     Sec-CH-UA-Mobile: "?1"
   os:
     name: Android
@@ -775,7 +775,7 @@
   user_agent: Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Mobile Safari/537.36
   headers:
     Sec-CH-UA: '"Chromium";v="106", "Brave Browser";v="106", "Not;A=Brand";v="99"'
-    Sec-CH-UA-Platform: "Android"
+    Sec-CH-UA-Platform: '"Android"'
     Sec-CH-UA-Mobile: "?1"
   os:
     name: Android
@@ -819,9 +819,9 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36
   headers:
     Sec-CH-UA: '"Not.A/Brand";v="8", "Chromium";v="114", "Google Chrome";v="114"'
-    Sec-CH-UA-Platform: "Android"
+    Sec-CH-UA-Platform: '"Android"'
     Sec-CH-UA-Mobile: "?1"
-    Sec-CH-UA-Full-Version: "114.0.5735.196"
+    Sec-CH-UA-Full-Version: '"114.0.5735.196"'
     Sec-CH-UA-Platform-Version: "10.0.0"
     Sec-CH-UA-Model: "Mi 9 SE"
     Sec-CH-Prefers-Color-Scheme: "light"
@@ -845,9 +845,9 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36
   headers:
     Sec-CH-UA: '"Not.A/Brand";v="8", "Chromium";v="114", "Google Chrome";v="114"'
-    Sec-CH-UA-Platform: "Android"
+    Sec-CH-UA-Platform: '"Android"'
     Sec-CH-UA-Mobile: "?1"
-    Sec-CH-UA-Full-Version: "114.0.5735.196"
+    Sec-CH-UA-Full-Version: '"114.0.5735.196"'
     Sec-CH-UA-Platform-Version: "11.0.0"
     Sec-CH-UA-Model: "SM-A105F"
     Sec-CH-Prefers-Color-Scheme: "light"
@@ -871,9 +871,9 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Mobile Safari/537.36
   headers:
     Sec-CH-UA: '"Google Chrome";v="111", "Not(A:Brand";v="8", "Chromium";v="111"'
-    Sec-CH-UA-Platform: "Android"
+    Sec-CH-UA-Platform: '"Android"'
     Sec-CH-UA-Mobile: "?1"
-    Sec-CH-UA-Full-Version: "111.0.5563.116"
+    Sec-CH-UA-Full-Version: '"111.0.5563.116"'
     Sec-CH-UA-Platform-Version: "13.0.0"
     Sec-CH-UA-Model: "22071219CG"
     Sec-CH-Prefers-Color-Scheme: "light"
@@ -897,9 +897,9 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Mobile Safari/537.36
   headers:
     Sec-CH-UA: '"Google Chrome";v="111", "Not(A:Brand";v="8", "Chromium";v="111"'
-    Sec-CH-UA-Platform: "Android"
+    Sec-CH-UA-Platform: '"Android"'
     Sec-CH-UA-Mobile: "?1"
-    Sec-CH-UA-Full-Version: "111.0.5563.116"
+    Sec-CH-UA-Full-Version: '"111.0.5563.116"'
     Sec-CH-UA-Platform-Version: ""
     Sec-CH-UA-Model: "22071219CG"
     Sec-CH-Prefers-Color-Scheme: "light"
@@ -1083,9 +1083,9 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 Avira/116.0.0.0
   headers:
     Sec-CH-UA: '"Chromium";v="116.0.22144.111", "Not)A;Brand";v="24.0.0.0", "Avira Secure Browser";v="116.0.22144.111"'
-    Sec-CH-UA-Platform: "Windows"
+    Sec-CH-UA-Platform: '"Windows"'
     Sec-CH-UA-Mobile: "?0"
-    Sec-CH-UA-Full-Version: "116.0.22144.111"
+    Sec-CH-UA-Full-Version: '"116.0.22144.111"'
     Sec-CH-UA-Platform-Version: "15.0.0"
     Sec-CH-UA-Arch: "x86"
     Sec-CH-UA-Bitness: '"64"'


### PR DESCRIPTION
Since clients provide these headers in quoted form, the related logic is off in real-world use.

References:
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-CH-UA-Platform
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-CH-UA-Platform-Version